### PR TITLE
1. INS-29090: Cloudwatch_logs - set  the "interval" default value fro…

### DIFF
--- a/filter-plugin/logstash-filter-aurora-mysql-guardium/AuroraMysqlOverCloudwatchPackage/gi_templates.json
+++ b/filter-plugin/logstash-filter-aurora-mysql-guardium/AuroraMysqlOverCloudwatchPackage/gi_templates.json
@@ -16,7 +16,7 @@
       },
       "interval": {
         "type": "number",
-        "default": 5,
+        "default": 900,
         "label": "Interval"
       },
       "region": {

--- a/filter-plugin/logstash-filter-documentdb-aws-guardium/DocumentDBOverCloudwatchPackage/gi_templates.json
+++ b/filter-plugin/logstash-filter-documentdb-aws-guardium/DocumentDBOverCloudwatchPackage/gi_templates.json
@@ -16,7 +16,7 @@
       },
       "interval": {
         "type": "number",
-        "default": 5,
+        "default": 900,
         "label": "Interval"
       },
       "region": {

--- a/filter-plugin/logstash-filter-mariadb-aws-guardium/MariaDBOverCloudWatchPackage/gi_templates.json
+++ b/filter-plugin/logstash-filter-mariadb-aws-guardium/MariaDBOverCloudWatchPackage/gi_templates.json
@@ -16,7 +16,7 @@
       },
       "interval": {
         "type": "number",
-        "default": 5,
+        "default": 900,
         "label": "Interval"
       },
       "region": {

--- a/filter-plugin/logstash-filter-mssql-guardium/MssqlOnPremOverJdbcPackage/gi_templates.json
+++ b/filter-plugin/logstash-filter-mssql-guardium/MssqlOnPremOverJdbcPackage/gi_templates.json
@@ -40,7 +40,7 @@
       },
       "statement_from": {
         "type": "text",
-        "default": "sys.fn_get_audit_file('C:\\\\AuditLogFiles\\\\*.sqlaudit', DEFAULT, DEFAULT)",
+        "default": "sys.fn_get_audit_file('C:\\\\MSSQL\\\\*.sqlaudit', DEFAULT, DEFAULT)",
         "label": "FROM"
       },
       "statement_where": {

--- a/filter-plugin/logstash-filter-mysql-aws-guardium/MysqlOverCloudwatchLogsPackage/gi_templates.json
+++ b/filter-plugin/logstash-filter-mysql-aws-guardium/MysqlOverCloudwatchLogsPackage/gi_templates.json
@@ -16,7 +16,7 @@
       },
       "interval": {
         "type": "number",
-        "default": 5,
+        "default": 900,
         "label": "Interval"
       },
       "region": {

--- a/filter-plugin/logstash-filter-neptune-aws-guardium/NeptuneOverCloudWatchPackage/gi_templates.json
+++ b/filter-plugin/logstash-filter-neptune-aws-guardium/NeptuneOverCloudWatchPackage/gi_templates.json
@@ -16,7 +16,7 @@
       },
       "interval": {
         "type": "number",
-        "default": 5,
+        "default": 900,
         "label": "Interval"
       },
       "region": {

--- a/filter-plugin/logstash-filter-postgres-guardium/PostgresOverCloudWatchPackage/gi_templates.json
+++ b/filter-plugin/logstash-filter-postgres-guardium/PostgresOverCloudWatchPackage/gi_templates.json
@@ -16,7 +16,7 @@
       },
       "interval": {
         "type": "number",
-        "default": 5,
+        "default": 900,
         "label": "Interval"
       },
       "region": {

--- a/filter-plugin/logstash-filter-s3-guardium/S3OverCloudwatchLogsPackage/gi_templates.json
+++ b/filter-plugin/logstash-filter-s3-guardium/S3OverCloudwatchLogsPackage/gi_templates.json
@@ -16,7 +16,7 @@
       },
       "interval": {
         "type": "number",
-        "default": 5,
+        "default": 900,
         "label": "Interval"
       },
       "region": {

--- a/filter-plugin/logstash-filter-s3-guardium/S3OverSQSPackage/S3/manifest.json
+++ b/filter-plugin/logstash-filter-s3-guardium/S3OverSQSPackage/S3/manifest.json
@@ -5,7 +5,7 @@
 	"pipeline_type":"pull",
 	"plugin_version": "0.5.4",
 	"datasourceTypes": [{"type":"S3","supportedVersions": ["9.5.5"]}],
-	"supported_input_plugins": ["SQS_input"],
+	"supported_input_plugins": ["SQS_input","Cloudwatch_logs_input"],
 	"developer": "IBM",
 	"license": "Apache2.0",
 	"description": "Parses Amazon S3 database events into Guardium.",

--- a/input-plugin/logstash-input-jdbc/JdbcInputPackage/JDBC/input.conf
+++ b/input-plugin/logstash-input-jdbc/JdbcInputPackage/JDBC/input.conf
@@ -9,7 +9,7 @@ input {
         tracking_column_type => "guc_input_param_tracking_column_type"
         schedule => "guc_input_param_schedule"
         tracking_column => "guc_input_param_tracking_column"
-        last_run_metadata_path => "./.logstash_jdbc_last_run"
+        last_run_metadata_path => "/usr/share/logstash/data/logstash_jdbc_last_run"
         add_field => { "server_name" => "guc_input_param_server_name" }
         add_field => { "account_id" => "guc_input_param_account_id" }
         add_field => { "enrollmentId" => "guc_input_param_enrollmentId" }


### PR DESCRIPTION
…m 5 to 900 (except dynamo db)

2. INS-29969: JDBC last ru metadata path - defined a default file location for all the JDBC connection: /usr/share/logstash/data/logstash_jdbc_last_run
3. INS-30379: S3 - added the cloudwatch_logs input to the supported input plugins list.
4. INS-30150: fixed the  default 'FROM' value in on-prem JDBC connection