### PR TITLE
Remove LFD instructions from all plugins

### DIFF
--- a/filter-plugin/logstash-filter-couchdb-guardium/README.md
+++ b/filter-plugin/logstash-filter-couchdb-guardium/README.md
@@ -97,7 +97,7 @@ For example:
 The Guardium universal connector is the Guardium entry point for native audit logs. The Guardium universal connector identifies and parses the received events, and converts them to a standard Guardium format. The output of the Guardium universal connector is forwarded to the Guardium sniffer on the collector, for policy and auditing enforcements. Configure Guardium to read the native audit logs by customizing the CouchDB template.
 
 ## Before you begin
-* You must have Log Full Details policy enabled on the collector. The detailed steps can be found in step 4 on [this page](https://www.ibm.com/docs/en/guardium/11.4?topic=dpi-installing-testing-filter-input-plug-in-staging-guardium-system).
+* Configure the policies you require. See [policies](/../../#policies) for more information.
 * You must have permission for the S-Tap Management role.The admin user includes this role by default.
 * Download the [guardium_logstash-offline-plugin-couchDB.zip](CouchdbOverFilebeatPackage/guardium_logstash-offline-plugins-couchDB.zip) plug-in.
 * Download the plugin filter configuration file [couchdb.conf](couchdb.conf).

--- a/filter-plugin/logstash-filter-pubsub-bigquery-guardium/README.md
+++ b/filter-plugin/logstash-filter-pubsub-bigquery-guardium/README.md
@@ -135,7 +135,7 @@ project-id_bigquery.googleapis.com.
 The Guardium universal connector is the Guardium entry point for native audit/data_access logs. The Guardium universal connector identifies and parses the received events, and converts them to a standard Guardium format. The output of the Guardium universal connector is forwarded to the Guardium sniffer on the collector, for policy and auditing enforcements. Configure Guardium to read the native audit/data_access logs by customizing the BigQuery template.
 
 ### Before you begin
-* You must have Log Full Details policy enabled on the collector. The detailed steps can be found in step 4 on [this page](https://github.com/IBM/universal-connectors/blob/main/docs/developing_plugins_gdp.md).
+* Configure the policies you require. See [policies](/../../#policies) for more information.
 * You must have permission for the S-Tap Management role. The admin user includes this role by default
 * Download the [guardium_logstash-offline-plugins-ps-bigQuery.zip](BigQueryOverPubSubPackage/guardium_logstash-offline-plugins-ps-bigQuery.zip) plug-in.
 

--- a/filter-plugin/logstash-filter-pubsub-spanner-guardium/README.md
+++ b/filter-plugin/logstash-filter-pubsub-spanner-guardium/README.md
@@ -128,7 +128,7 @@ The inclusion filter mentioned above will be used to view the Audit logs in the 
 The Guardium universal connector is the Guardium entry point for native audit/data_access logs. The Guardium universal connector identifies and parses the received events, and converts them to a standard Guardium format. The output of the Guardium universal connector is forwarded to the Guardium sniffer on the collector, for policy and auditing enforcements. Configure Guardium to read the native audit/data_access logs by customizing the Spanner template.
 
 ### Before you begin
-* You must have Log Full Details policy enabled on the collector. The detailed steps can be found in step 4 under section Installing and testing the filter or input plug-in on a staging Guardium system on [this page](https://github.com/IBM/universal-connectors/raw/main/docs/developing_plugins_gdp.md).
+* Configure the policies you require. See [policies](/../../#policies) for more information.
 * You must have permission for the S-Tap Management role. The admin user includes this role by default.
 * Download the [guardium_logstash-offline-plugins-gcp-pubsub-spanner.zip](SpannerOverPubSubPackage/guardium_logstash-offline-plugins-gcp-pubsub-spanner.zip) plug-in.
 


### PR DESCRIPTION
Removed instructions to use LFD policy (the same way as the rest of the plugins)