### PR TITLE
GRD-73308 + GRD-73400

### DIFF
--- a/docs/Guardium Data Protection/uc_config_gdp.md
+++ b/docs/Guardium Data Protection/uc_config_gdp.md
@@ -142,9 +142,9 @@ Pre-defined plug-ins: Guardium has a few pre-defined plug-ins for specific data 
 
 •	The default MongoDB connector is the preferred method of ingesting data. It does not require any additional configuration on Guardium if you use the default configuration. By default, the Guardium universal connector listens for MongoDB audit log events that are sent over Syslog (TCP port 5000, UDP port 5141) and Filebeat (port 5044). If you cannot use these ports, or if a parameter does not display in the reports as you expect, update the MongoDB connector configuration to match your system.
 
-**Important: Each connector requires unique ports. Do not use the default ports for a customized connector configuration.**
+**Important: Each connector requires unique ports. Do not use the default ports for a customized connector configuration. Also, each connector must have a unique type, and the filter configuration must use that type.**
 
-•	Each MongDB connector on any one collector must have a unique type, and the filter configuration must use that type. For example, if the input configuration includes:
+For example, if the input configuration includes:
 ```
 udp { port => 5141 type => "syslogMongoDB" }
 ```

--- a/filter-plugin/logstash-filter-aurora-mysql-guardium/README.md
+++ b/filter-plugin/logstash-filter-aurora-mysql-guardium/README.md
@@ -128,12 +128,12 @@ The Guardium universal connector is the Guardium entry point for native audit lo
 
 • You must have permission for the S-Tap Management role. The admin user includes this role by default.
 	
-• Download the [Aurora-Mysql-offlinePlugin.zip](https://github.com/IBM/universal-connectors/raw/main/filter-plugin/logstash-filter-aurora-mysql-guardium/AuroraMysqlOverCloudwatchPackage/AuroraMysql/Aurora-Mysql-offlinePlugin.zip) plug-in.
+• Download the [Aurora-Mysql-offlinePlugin.zip](https://github.com/IBM/universal-connectors/raw/main/filter-plugin/logstash-filter-aurora-mysql-guardium/AuroraMysqlOverCloudwatchPackage/AuroraMysql/Aurora-Mysql-offlinePlugin.zip) plug-in. **This is not necessary for Guardium Data Protection v12.0 and later**.
 
 #### Procedure
 1. On the collector, go to Setup > Tools and Views > Configure Universal Connector.
 2. First enable the Universal Guardium connector, if it is disabled already.
-3. Click Upload File and select the offline [Aurora-Mysql-offlinePlugin.zip](https://github.com/IBM/universal-connectors/raw/main/filter-plugin/logstash-filter-aurora-mysql-guardium/AuroraMysqlOverCloudwatchPackage/AuroraMysql/Aurora-Mysql-offlinePlugin.zip) plug-in. After it is uploaded, click OK.						 
+3. Click Upload File and select the offline [Aurora-Mysql-offlinePlugin.zip](https://github.com/IBM/universal-connectors/raw/main/filter-plugin/logstash-filter-aurora-mysql-guardium/AuroraMysqlOverCloudwatchPackage/AuroraMysql/Aurora-Mysql-offlinePlugin.zip) plug-in. After it is uploaded, click OK. **This is not necessary for Guardium Data Protection v12.0 and later**,						 
 4. Click the Plus sign to open the Connector Configuration dialog box.
 5. Type a name in the Connector name field.
 6. Update the input section to add the details from [auroraMysqlCloudwatch.conf](https://github.com/IBM/universal-connectors/raw/main/filter-plugin/logstash-filter-aurora-mysql-guardium/auroraMysqlCloudwatch.conf) file's input part, omitting the keyword "input{" at the beginning and its corresponding "}" at the end.

--- a/filter-plugin/logstash-filter-aurora-mysql-guardium/README.md
+++ b/filter-plugin/logstash-filter-aurora-mysql-guardium/README.md
@@ -128,12 +128,12 @@ The Guardium universal connector is the Guardium entry point for native audit lo
 
 • You must have permission for the S-Tap Management role. The admin user includes this role by default.
 	
-• Download the [Aurora-Mysql-offlinePlugin.zip](https://github.com/IBM/universal-connectors/raw/main/filter-plugin/logstash-filter-aurora-mysql-guardium/AuroraMysqlOverCloudwatchPackage/AuroraMysql/Aurora-Mysql-offlinePlugin.zip) plug-in. **This is not necessary for Guardium Data Protection v12.0 and later**.
+• Download the [Aurora-Mysql-offlinePlugin.zip](https://github.com/IBM/universal-connectors/raw/main/filter-plugin/logstash-filter-aurora-mysql-guardium/AuroraMysqlOverCloudwatchPackage/AuroraMysql/Aurora-Mysql-offlinePlugin.zip) plug-in. This is not necessary for Guardium Data Protection v12.0 and later.
 
 #### Procedure
 1. On the collector, go to Setup > Tools and Views > Configure Universal Connector.
 2. First enable the Universal Guardium connector, if it is disabled already.
-3. Click Upload File and select the offline [Aurora-Mysql-offlinePlugin.zip](https://github.com/IBM/universal-connectors/raw/main/filter-plugin/logstash-filter-aurora-mysql-guardium/AuroraMysqlOverCloudwatchPackage/AuroraMysql/Aurora-Mysql-offlinePlugin.zip) plug-in. After it is uploaded, click OK. **This is not necessary for Guardium Data Protection v12.0 and later**,						 
+3. Click Upload File and select the offline [Aurora-Mysql-offlinePlugin.zip](https://github.com/IBM/universal-connectors/raw/main/filter-plugin/logstash-filter-aurora-mysql-guardium/AuroraMysqlOverCloudwatchPackage/AuroraMysql/Aurora-Mysql-offlinePlugin.zip) plug-in. After it is uploaded, click OK. This is not necessary for Guardium Data Protection v12.0 and later.						 
 4. Click the Plus sign to open the Connector Configuration dialog box.
 5. Type a name in the Connector name field.
 6. Update the input section to add the details from [auroraMysqlCloudwatch.conf](https://github.com/IBM/universal-connectors/raw/main/filter-plugin/logstash-filter-aurora-mysql-guardium/auroraMysqlCloudwatch.conf) file's input part, omitting the keyword "input{" at the beginning and its corresponding "}" at the end.

--- a/filter-plugin/logstash-filter-azure-apachesolr-guardium/README.md
+++ b/filter-plugin/logstash-filter-azure-apachesolr-guardium/README.md
@@ -171,13 +171,13 @@ The Guardium universal connector is the Guardium entry point for native audit lo
 
 * Configure the policies you require. See [policies](/docs/#policies) for more information. 
 * You must have permission for the S-Tap Management role. The admin user includes this role by default.
-* Download the [guardium_logstash-offline-plugin-apache-solr-azure.zip](https://github.com/IBM/universal-connectors/raw/INS-30373/filter-plugin/logstash-filter-azure-apachesolr-guardium/ApacheSolrOverFilebeatPackage/AzureSolr/guardium_logstash-offline-plugin-apache-solr-azure.zip) plug-in.
+* Download the [guardium_logstash-offline-plugin-apache-solr-azure.zip](https://github.com/IBM/universal-connectors/raw/INS-30373/filter-plugin/logstash-filter-azure-apachesolr-guardium/ApacheSolrOverFilebeatPackage/AzureSolr/guardium_logstash-offline-plugin-apache-solr-azure.zip) plug-in. This is not necessary for Guardium Data Protection v12.0 and later.
 
 ### Procedure
 
 1. On the collector, go to Setup > Tools and Views > Configure Universal Connector.
 2. First, enable the Universal Guardium connector, if it is currently disabled.
-3. Click Upload File and select the offline [guardium_logstash-offline-plugin-apache-solr-azure.zip](https://github.com/IBM/universal-connectors/raw/INS-30373/filter-plugin/logstash-filter-azure-apachesolr-guardium/ApacheSolrOverFilebeatPackage/AzureSolr/guardium_logstash-offline-plugin-apache-solr-azure.zip) plug-in. After it is uploaded, click OK.
+3. Click Upload File and select the offline [guardium_logstash-offline-plugin-apache-solr-azure.zip](https://github.com/IBM/universal-connectors/raw/INS-30373/filter-plugin/logstash-filter-azure-apachesolr-guardium/ApacheSolrOverFilebeatPackage/AzureSolr/guardium_logstash-offline-plugin-apache-solr-azure.zip) plug-in. After it is uploaded, click OK. This is not necessary for Guardium Data Protection v12.0 and later.
 4. Click the Plus icon to open the Connector Configuration dialog box.
 5. Type a name in the Connector name field.
 6. Update the input section to add the details from the [solrazure.conf](solrazure.conf) file's input part, omitting the keyword "input{" at the beginning and its corresponding "}" at the end.

--- a/filter-plugin/logstash-filter-azure-postgresql-guardium/README.md
+++ b/filter-plugin/logstash-filter-azure-postgresql-guardium/README.md
@@ -158,13 +158,13 @@ The Guardium universal connector is the Guardium entry point for native audit lo
 																	
 • You must have permission for the S-Tap Management role. The admin user includes this role by default.
 
-• Download the [azure-postgresql-offline-plugins-7.5.2.zip](https://github.com/IBM/universal-connectors/raw/main/filter-plugin/logstash-filter-azure-postgresql-guardium/AzurePostgresqlOverAzureEventHub/azurepostgresql/azure-postgresql-offline-plugins-7.5.2.zip) plug-in.		 
+• Download the [azure-postgresql-offline-plugins-7.5.2.zip](https://github.com/IBM/universal-connectors/raw/main/filter-plugin/logstash-filter-azure-postgresql-guardium/AzurePostgresqlOverAzureEventHub/azurepostgresql/azure-postgresql-offline-plugins-7.5.2.zip) plug-in. This is not necessary for Guardium Data Protection v12.0 and later. 
 
 #### Procedure : 
 
 1.	On the collector, go to Setup > Tools and Views > Configure Universal Connector.
 2.	First enable the Universal Guardium connector, if it is disabled already.
-3.	Click Upload File and select the offline [azure-postgresql-offline-plugins-7.5.2.zip](https://github.com/IBM/universal-connectors/raw/main/filter-plugin/logstash-filter-azure-postgresql-guardium/AzurePostgresqlOverAzureEventHub/azurepostgresql/azure-postgresql-offline-plugins-7.5.2.zip) plugin. After it is uploaded,click OK.
+3.	Click Upload File and select the offline [azure-postgresql-offline-plugins-7.5.2.zip](https://github.com/IBM/universal-connectors/raw/main/filter-plugin/logstash-filter-azure-postgresql-guardium/AzurePostgresqlOverAzureEventHub/azurepostgresql/azure-postgresql-offline-plugins-7.5.2.zip) plugin. After it is uploaded,click OK. This is not necessary for Guardium Data Protection v12.0 and later.
 4.	Click the Plus sign to open the Connector Configuration dialog box.
 5.	Type a name in the Connector name field.
 6.	Update the input section to add the details from [azurepostgresql.conf](https://github.com/IBM/universal-connectors/raw/main/filter-plugin/logstash-filter-azure-postgresql-guardium/azurepostgresql.conf) file's input part, omitting the keyword "input{" at the beginning and its corresponding "}" at the end.

--- a/filter-plugin/logstash-filter-azure-sql-guardium/README.md
+++ b/filter-plugin/logstash-filter-azure-sql-guardium/README.md
@@ -125,7 +125,7 @@ The Guardium universal connector is the Guardium entry point for native audit lo
 
 • You must have permission for the S-Tap Management role. The admin user includes this role by default.
 
-• Download the [Azure-SQL-Offline-Package.zip](https://github.com/IBM/universal-connectors/raw/main/filter-plugin/logstash-filter-azure-sql-guardium/AzureSQLOverJdbcPackage/AzureSQL/Azure-SQL-Offline-Package.zip) plug-in.
+• Download the [Azure-SQL-Offline-Package.zip](https://github.com/IBM/universal-connectors/raw/main/filter-plugin/logstash-filter-azure-sql-guardium/AzureSQLOverJdbcPackage/AzureSQL/Azure-SQL-Offline-Package.zip) plug-in. This is not necessary for Guardium Data Protection v12.0 and later.
 
 • Download the mssql-jdbc-7.4.1.jre8 from [here](https://jar-download.com/artifacts/com.microsoft.sqlserver/mssql-jdbc/7.4.1.jre8)
 
@@ -133,7 +133,7 @@ The Guardium universal connector is the Guardium entry point for native audit lo
 
 1. On the collector, go to Setup > Tools and Views > Configure Universal Connector.
 2. First enable the Universal Guardium connector, if it is disabled already.
-3. Click Upload File and select the offline [Azure-SQL-Offline-Package.zip](https://github.com/IBM/universal-connectors/raw/main/filter-plugin/logstash-filter-azure-sql-guardium/AzureSQLOverJdbcPackage/AzureSQL/Azure-SQL-Offline-Package.zip) plug-in. After it is uploaded, click OK.
+3. Click Upload File and select the offline [Azure-SQL-Offline-Package.zip](https://github.com/IBM/universal-connectors/raw/main/filter-plugin/logstash-filter-azure-sql-guardium/AzureSQLOverJdbcPackage/AzureSQL/Azure-SQL-Offline-Package.zip) plug-in. After it is uploaded, click OK. This is not necessary for Guardium Data Protection v12.0 and later.
 4. Again click Upload File and select the offline mssql-jdbc-7.4.1.jre8 file. After it is uploaded, click OK. . 
 5. Click the Plus sign to open the Connector Configuration dialog box.
 6. Type a name in the Connector name field.

--- a/filter-plugin/logstash-filter-cassandra-guardium/README.md
+++ b/filter-plugin/logstash-filter-cassandra-guardium/README.md
@@ -119,12 +119,12 @@ The Guardium universal connector is the Guardium entry point for native audit lo
 
 • You must have permission for the S-Tap Management role. The admin user includes this role, by default.
 
-• Download the [cassandra-offline-plugins-7.5.2.zip plug-in.](https://github.com/IBM/universal-connectors/raw/main/filter-plugin/logstash-filter-cassandra-guardium/CassandraOverFilebeatPackage/Cassandra/cassandra-offline-plugins-7.5.2.zip)																	
+• Download the [cassandra-offline-plugins-7.5.2.zip plug-in.](https://github.com/IBM/universal-connectors/raw/main/filter-plugin/logstash-filter-cassandra-guardium/CassandraOverFilebeatPackage/Cassandra/cassandra-offline-plugins-7.5.2.zip) This is not necessary for Guardium Data Protection v12.0 and later.													
 ### Procedure
 
 1. On the collector, go to Setup > Tools and Views > Configure Universal Connector.
 2. First enable the Universal Guardium connector, if it is disabled already.
-3. Click Upload File and select the offline [cassandra-offline-plugins-7.5.2.zip plug-in.](https://github.com/IBM/universal-connectors/raw/main/filter-plugin/logstash-filter-cassandra-guardium/CassandraOverFilebeatPackage/Cassandra/cassandra-offline-plugins-7.5.2.zip) plug-in. After it is uploaded, click OK.
+3. Click Upload File and select the offline [cassandra-offline-plugins-7.5.2.zip plug-in.](https://github.com/IBM/universal-connectors/raw/main/filter-plugin/logstash-filter-cassandra-guardium/CassandraOverFilebeatPackage/Cassandra/cassandra-offline-plugins-7.5.2.zip) plug-in. After it is uploaded, click OK. This is not necessary for Guardium Data Protection v12.0 and later.
 4. Click the Plus sign to open the Connector Configuration dialog box.
 5. Type a name in the Connector name field.
 6. Update the input section to add the details from the [filter-test-beats.conf](https://github.com/IBM/universal-connectors/raw/main/filter-plugin/logstash-filter-cassandra-guardium/filter-test-beats.conf) file's input part, omitting the keyword "input{" at the beginning and its corresponding "}" at the end.

--- a/filter-plugin/logstash-filter-couchbasedb-guardium/README.md
+++ b/filter-plugin/logstash-filter-couchbasedb-guardium/README.md
@@ -117,13 +117,13 @@ The Guardium universal connector is the Guardium entry point for native audit lo
 
 • You must have permission for the S-Tap Management role. The admin user includes this role, by default.
 
-• Download the [couchbase-offline-pack.zip](https://github.com/IBM/universal-connectors/raw/main/filter-plugin/logstash-filter-couchbasedb-guardium/CouchbasedbOverFilebeatPackage/CouchbaseDB/couchbase-offline-pack.zip) 
+• Download the [couchbase-offline-pack.zip](https://github.com/IBM/universal-connectors/raw/main/filter-plugin/logstash-filter-couchbasedb-guardium/CouchbasedbOverFilebeatPackage/CouchbaseDB/couchbase-offline-pack.zip) This is not necessary for Guardium Data Protection v12.0 and later.
 
 #### Procedure
 
 1. On the collector, go to Setup > Tools and Views > Configure Universal Connector.
 2. First enable the Universal Guardium connector, if it is disabled already.
-3. Click Upload File and select the offline plug-in named [couchbase-offline-pack.zip](https://github.com/IBM/universal-connectors/raw/main/filter-plugin/logstash-filter-couchbasedb-guardium/CouchbasedbOverFilebeatPackage/CouchbaseDB/couchbase-offline-pack.zip). After it is uploaded, click OK.
+3. Click Upload File and select the offline plug-in named [couchbase-offline-pack.zip](https://github.com/IBM/universal-connectors/raw/main/filter-plugin/logstash-filter-couchbasedb-guardium/CouchbasedbOverFilebeatPackage/CouchbaseDB/couchbase-offline-pack.zip). After it is uploaded, click OK. This is not necessary for Guardium Data Protection v12.0 and later.
 4. Click the Plus sign icon. The Connector Configuration dialog box opens.
 5. Type a name in the Connector name field.
 6. Update the input section to add the details from the [couchbasedbFilebeat.conf](https://github.com/IBM/universal-connectors/raw/main/filter-plugin/logstash-filter-couchbasedb-guardium/couchbasedbFilebeat.conf) file's input part, omitting the keyword "input{" at the beginning and its corresponding "}" at the end. On the Logstash server, ensure that the port that you want to use is free. This port should should be same as the port number defined in the filebeat.yml file.

--- a/filter-plugin/logstash-filter-couchdb-guardium/README.md
+++ b/filter-plugin/logstash-filter-couchdb-guardium/README.md
@@ -99,13 +99,13 @@ The Guardium universal connector is the Guardium entry point for native audit lo
 ## Before you begin
 * Configure the policies you require. See [policies](/docs/#policies) for more information.
 * You must have permission for the S-Tap Management role.The admin user includes this role by default.
-* Download the [guardium_logstash-offline-plugin-couchDB.zip](CouchdbOverFilebeatPackage/guardium_logstash-offline-plugins-couchDB.zip) plug-in.
+* Download the [guardium_logstash-offline-plugin-couchDB.zip](CouchdbOverFilebeatPackage/guardium_logstash-offline-plugins-couchDB.zip) plug-in. This is not necessary for Guardium Data Protection v12.0 and later.
 * Download the plugin filter configuration file [couchdb.conf](couchdb.conf).
 
 ## Procedure
 1. On the collector, go to Setup > Tools and Views > Configure Universal Connector.
 2. Enable the connector if it is disabled before uploading the UC plug-in.
-3. Click Upload File and select the offline [guardium_logstash-offline-plugin-couchdb.zip](CouchdbOverFilebeatPackage/guardium_logstash-offline-plugins-couchDB.zip) plug-in. After it is uploaded, click OK.
+3. Click Upload File and select the offline [guardium_logstash-offline-plugin-couchdb.zip](CouchdbOverFilebeatPackage/guardium_logstash-offline-plugins-couchDB.zip) plug-in. After it is uploaded, click OK. This is not necessary for Guardium Data Protection v12.0 and later.
 4. Click the Plus sign to open the Connector Configuration dialog box.
 5. Type a name in the Connector name field.
 6. Update the input section to add the details from [couchdb.conf](couchdb.conf) file's input part, omitting the keyword "input{" at the beginning and its corresponding "}" at the end.

--- a/filter-plugin/logstash-filter-documentdb-aws-guardium/README.md
+++ b/filter-plugin/logstash-filter-documentdb-aws-guardium/README.md
@@ -101,13 +101,13 @@ The Guardium universal connector is the Guardium entry point for native audit/pr
 ### Before you begin
 * Configure the policies you require. See [policies](/docs/#policies) for more information.
 * You must have permission for the S-Tap Management role.The admin user includes this role by     default.
-* Download the [guardium_logstash-offline-plugin-documentdb.zip](https://github.com/IBM/universal-connectors/raw/main/filter-plugin/logstash-filter-documentdb-aws-guardium/DocumentDBOverCloudwatchPackage/DocumentDB/guardium_logstash-offline-plugin-documentdb.zip) plug-in.
+* Download the [guardium_logstash-offline-plugin-documentdb.zip](https://github.com/IBM/universal-connectors/raw/main/filter-plugin/logstash-filter-documentdb-aws-guardium/DocumentDBOverCloudwatchPackage/DocumentDB/guardium_logstash-offline-plugin-documentdb.zip) plug-in. This is not necessary for Guardium Data Protection v12.0 and later.
 * Download the plugin filter configuration file [ documentDBCloudwatch.conf](https://github.com/IBM/universal-connectors/raw/main/filter-plugin/logstash-filter-documentdb-aws-guardium/documentDBCloudwatch.conf).
 
 ### Procedure
 1. On the collector, go to Setup > Tools and Views > Configure Universal Connector.
 2. First Enable the Universal Guardium connector, if it is disabled already.
-3. Click Upload File and select the [offline guardium_logstash-offline-plugin-documentdb.zip](https://github.com/IBM/universal-connectors/raw/main/filter-plugin/logstash-filter-documentdb-aws-guardium/DocumentDBOverCloudwatchPackage/DocumentDB/guardium_logstash-offline-plugin-documentdb.zip) plug-in. After it is uploaded, click OK.
+3. Click Upload File and select the [offline guardium_logstash-offline-plugin-documentdb.zip](https://github.com/IBM/universal-connectors/raw/main/filter-plugin/logstash-filter-documentdb-aws-guardium/DocumentDBOverCloudwatchPackage/DocumentDB/guardium_logstash-offline-plugin-documentdb.zip) plug-in. After it is uploaded, click OK. This is not necessary for Guardium Data Protection v12.0 and later.
 4. Click the Plus sign to open the Connector Configuration dialog box.
 5. Type a name in the Connector name field.
 6. Update the input section to add the details from [documentDBCloudwatch.conf](https://github.com/IBM/universal-connectors/raw/main/filter-plugin/logstash-filter-documentdb-aws-guardium/documentDBCloudwatch.conf) file's input part, omitting the keyword "input{" at the beginning and its corresponding "}" at the end.

--- a/filter-plugin/logstash-filter-dynamodb-guardium/README.md
+++ b/filter-plugin/logstash-filter-dynamodb-guardium/README.md
@@ -115,14 +115,14 @@ The Guardium universal connector is the Guardium entry point for native audit lo
 
 • You must have permission for the S-Tap Management role. The admin user includes this role by default.
 
-• Download the [dynamodb-offline-plugins-7.5.2.zip](https://github.com/IBM/universal-connectors/raw/main/filter-plugin/logstash-filter-dynamodb-guardium/DynamodbOverCloudwatchPackage/DynamoDB/dynamodb-offline-plugins-7.5.2.zip) plug-in.
+• Download the [dynamodb-offline-plugins-7.5.2.zip](https://github.com/IBM/universal-connectors/raw/main/filter-plugin/logstash-filter-dynamodb-guardium/DynamodbOverCloudwatchPackage/DynamoDB/dynamodb-offline-plugins-7.5.2.zip) plug-in. **This is not necessary for Guardium Data Protection v12.0 and later**.
 
 
 ### Procedure
 
 1. On the collector, navigate to Setup > Tools and Views > Configure Universal Connector
 2. First enable the Universal Guardium connector, if it is disabled already
-3. Click Upload File and select the offline plug-in named [dynamodb-offline-plugins-7.5.2.zip](https://github.com/IBM/universal-connectors/raw/main/filter-plugin/logstash-filter-dynamodb-guardium/DynamodbOverCloudwatchPackage/DynamoDB/dynamodb-offline-plugins-7.5.2.zip)plug-in. After it is uploaded, click OK.
+3. Click Upload File and select the offline plug-in named [dynamodb-offline-plugins-7.5.2.zip](https://github.com/IBM/universal-connectors/raw/main/filter-plugin/logstash-filter-dynamodb-guardium/DynamodbOverCloudwatchPackage/DynamoDB/dynamodb-offline-plugins-7.5.2.zip)plug-in. After it is uploaded, click OK. **This is not necessary for Guardium Data Protection v12.0 and later**.
 4. Click the Plus sign to open the Connector Configuration dialog box
 5. Type a name in the Connector name field.
 6. Update the input section to add the details from the [dynamodbCloudwatch.conf](https://github.com/IBM/universal-connectors/raw/main/filter-plugin/logstash-filter-dynamodb-guardium/dynamodbCloudwatch.conf) file's input part, omitting the keyword "input{" at the beginning and its corresponding "}" at the end

--- a/filter-plugin/logstash-filter-dynamodb-guardium/README.md
+++ b/filter-plugin/logstash-filter-dynamodb-guardium/README.md
@@ -115,14 +115,14 @@ The Guardium universal connector is the Guardium entry point for native audit lo
 
 • You must have permission for the S-Tap Management role. The admin user includes this role by default.
 
-• Download the [dynamodb-offline-plugins-7.5.2.zip](https://github.com/IBM/universal-connectors/raw/main/filter-plugin/logstash-filter-dynamodb-guardium/DynamodbOverCloudwatchPackage/DynamoDB/dynamodb-offline-plugins-7.5.2.zip) plug-in. **This is not necessary for Guardium Data Protection v12.0 and later**.
+• Download the [dynamodb-offline-plugins-7.5.2.zip](https://github.com/IBM/universal-connectors/raw/main/filter-plugin/logstash-filter-dynamodb-guardium/DynamodbOverCloudwatchPackage/DynamoDB/dynamodb-offline-plugins-7.5.2.zip) plug-in. This is not necessary for Guardium Data Protection v12.0 and later.
 
 
 ### Procedure
 
 1. On the collector, navigate to Setup > Tools and Views > Configure Universal Connector
 2. First enable the Universal Guardium connector, if it is disabled already
-3. Click Upload File and select the offline plug-in named [dynamodb-offline-plugins-7.5.2.zip](https://github.com/IBM/universal-connectors/raw/main/filter-plugin/logstash-filter-dynamodb-guardium/DynamodbOverCloudwatchPackage/DynamoDB/dynamodb-offline-plugins-7.5.2.zip)plug-in. After it is uploaded, click OK. **This is not necessary for Guardium Data Protection v12.0 and later**.
+3. Click Upload File and select the offline plug-in named [dynamodb-offline-plugins-7.5.2.zip](https://github.com/IBM/universal-connectors/raw/main/filter-plugin/logstash-filter-dynamodb-guardium/DynamodbOverCloudwatchPackage/DynamoDB/dynamodb-offline-plugins-7.5.2.zip)plug-in. After it is uploaded, click OK. This is not necessary for Guardium Data Protection v12.0 and later.
 4. Click the Plus sign to open the Connector Configuration dialog box
 5. Type a name in the Connector name field.
 6. Update the input section to add the details from the [dynamodbCloudwatch.conf](https://github.com/IBM/universal-connectors/raw/main/filter-plugin/logstash-filter-dynamodb-guardium/dynamodbCloudwatch.conf) file's input part, omitting the keyword "input{" at the beginning and its corresponding "}" at the end

--- a/filter-plugin/logstash-filter-mariadb-aws-guardium/README.md
+++ b/filter-plugin/logstash-filter-mariadb-aws-guardium/README.md
@@ -115,13 +115,13 @@ The Guardium universal connector is the Guardium entry point for native audit lo
 *  Configure the policies you require. See [policies](/docs/#policies) for more information.
 * You must have permission for the S-Tap Management role. The admin user includes this role by default.
 * Download the [logstash-filter-awsmariadb_guardium_filter](https://github.com/IBM/universal-connectors/raw/main/filter-plugin/logstash-filter-mariadb-aws-guardium/MariaDBOverCloudWatchPackage/MariaDB/logstash-filter-awsmariadb_guardium_filter.zip) plug-in.
-* Download the plugin filter configuration file [MariaDBCloudWatch.conf](https://github.com/IBM/universal-connectors/raw/main/filter-plugin/logstash-filter-mariadb-aws-guardium/MariaDBCloudWatch.conf).
+* Download the plug-in filter configuration file [MariaDBCloudWatch.conf](https://github.com/IBM/universal-connectors/raw/main/filter-plugin/logstash-filter-mariadb-aws-guardium/MariaDBCloudWatch.conf). **This is not necessary for Guardium Data Protection v12.0 and later**.
 
 #### Procedure
 
 1. On the collector, go to Setup > Tools and Views > Configure Universal Connector.
 2. Enable the connector if it is disabled before uploading the UC plug-in.	
-3. Click Upload File and select [logstash-filter-awsmariadb_guardium_filter](https://github.com/IBM/universal-connectors/raw/main/filter-plugin/logstash-filter-mariadb-aws-guardium/MariaDBOverCloudWatchPackage/MariaDB/logstash-filter-awsmariadb_guardium_filter.zip) plug-in. After it is uploaded, click OK.
+3. Click Upload File and select [logstash-filter-awsmariadb_guardium_filter](https://github.com/IBM/universal-connectors/raw/main/filter-plugin/logstash-filter-mariadb-aws-guardium/MariaDBOverCloudWatchPackage/MariaDB/logstash-filter-awsmariadb_guardium_filter.zip) plug-in. After it is uploaded, click OK. **This is not necessary for Guardium Data Protection v12.0 and later**.
 4. Click the Plus sign to open the Connector Configuration dialog box.
 5. Type a name in the Connector name field.
 6. Update the input section to add the details from [MariaDBCloudWatch.conf](https://github.com/IBM/universal-connectors/raw/main/filter-plugin/logstash-filter-mariadb-aws-guardium/MariaDBCloudWatch.conf) file's input part, omitting the keyword "input{" at the beginning and its corresponding "}" at the end.

--- a/filter-plugin/logstash-filter-mariadb-aws-guardium/README.md
+++ b/filter-plugin/logstash-filter-mariadb-aws-guardium/README.md
@@ -115,13 +115,13 @@ The Guardium universal connector is the Guardium entry point for native audit lo
 *  Configure the policies you require. See [policies](/docs/#policies) for more information.
 * You must have permission for the S-Tap Management role. The admin user includes this role by default.
 * Download the [logstash-filter-awsmariadb_guardium_filter](https://github.com/IBM/universal-connectors/raw/main/filter-plugin/logstash-filter-mariadb-aws-guardium/MariaDBOverCloudWatchPackage/MariaDB/logstash-filter-awsmariadb_guardium_filter.zip) plug-in.
-* Download the plug-in filter configuration file [MariaDBCloudWatch.conf](https://github.com/IBM/universal-connectors/raw/main/filter-plugin/logstash-filter-mariadb-aws-guardium/MariaDBCloudWatch.conf). **This is not necessary for Guardium Data Protection v12.0 and later**.
+* Download the plug-in filter configuration file [MariaDBCloudWatch.conf](https://github.com/IBM/universal-connectors/raw/main/filter-plugin/logstash-filter-mariadb-aws-guardium/MariaDBCloudWatch.conf). This is not necessary for Guardium Data Protection v12.0 and later.
 
 #### Procedure
 
 1. On the collector, go to Setup > Tools and Views > Configure Universal Connector.
 2. Enable the connector if it is disabled before uploading the UC plug-in.	
-3. Click Upload File and select [logstash-filter-awsmariadb_guardium_filter](https://github.com/IBM/universal-connectors/raw/main/filter-plugin/logstash-filter-mariadb-aws-guardium/MariaDBOverCloudWatchPackage/MariaDB/logstash-filter-awsmariadb_guardium_filter.zip) plug-in. After it is uploaded, click OK. **This is not necessary for Guardium Data Protection v12.0 and later**.
+3. Click Upload File and select [logstash-filter-awsmariadb_guardium_filter](https://github.com/IBM/universal-connectors/raw/main/filter-plugin/logstash-filter-mariadb-aws-guardium/MariaDBOverCloudWatchPackage/MariaDB/logstash-filter-awsmariadb_guardium_filter.zip) plug-in. After it is uploaded, click OK. This is not necessary for Guardium Data Protection v12.0 and later.
 4. Click the Plus sign to open the Connector Configuration dialog box.
 5. Type a name in the Connector name field.
 6. Update the input section to add the details from [MariaDBCloudWatch.conf](https://github.com/IBM/universal-connectors/raw/main/filter-plugin/logstash-filter-mariadb-aws-guardium/MariaDBCloudWatch.conf) file's input part, omitting the keyword "input{" at the beginning and its corresponding "}" at the end.

--- a/filter-plugin/logstash-filter-mariadb-guardium/README.md
+++ b/filter-plugin/logstash-filter-mariadb-guardium/README.md
@@ -173,13 +173,13 @@ The Guardium universal connector is the Guardium entry point for native audit lo
  
 ## Before you begin
 * You must have permission for the S-Tap Management role. The admin user includes this role by default.
-* Download the [logstash-filter-mariadb_guardium_filter.zip](https://github.com/IBM/universal-connectors/raw/main/filter-plugin/logstash-filter-mariadb-guardium/MariaDBOverFilebeatPackage/MariaDB/logstash-filter-mariadb_guardium_filter.zip) plug-in.
-* Download the plugin filter configuration file [MariaDB.conf](https://github.com/IBM/universal-connectors/raw/main/filter-plugin/logstash-filter-mariadb-guardium/MariaDB.conf).
+* Download the [logstash-filter-mariadb_guardium_filter.zip](https://github.com/IBM/universal-connectors/raw/main/filter-plugin/logstash-filter-mariadb-guardium/MariaDBOverFilebeatPackage/MariaDB/logstash-filter-mariadb_guardium_filter.zip) plug-in. This is not necessary for Guardium Data Protection v12.0 and later.
+* Download the filter plug-in configuration file [MariaDB.conf](https://github.com/IBM/universal-connectors/raw/main/filter-plugin/logstash-filter-mariadb-guardium/MariaDB.conf).
 
 ## Procedure
 1. On the collector, go to Setup > Tools and Views > Configure Universal Connector.
 2. Enable the connector if it is disabled before uploading the UC plug-in.	
-3. Click ```Upload File``` and select the offline [logstash-filter-mariadb_guardium_filter.zip](https://github.com/IBM/universal-connectors/raw/main/filter-plugin/logstash-filter-mariadb-guardium/MariaDBOverFilebeatPackage/MariaDB/logstash-filter-mariadb_guardium_filter.zip) plug-in. After it is uploaded, click ```OK```.
+3. Click **Upload File** and select the offline [logstash-filter-mariadb_guardium_filter.zip](https://github.com/IBM/universal-connectors/raw/main/filter-plugin/logstash-filter-mariadb-guardium/MariaDBOverFilebeatPackage/MariaDB/logstash-filter-mariadb_guardium_filter.zip) plug-in. After it is uploaded, click **OK**. This is not necessary for Guardium Data Protection v12.0 and later.
 4. Click the Plus sign to open the Connector Configuration dialog box.
 5. Type a name in the Connector name field.
 6. Update the input section to add the details from [mariadb.conf](https://github.com/IBM/universal-connectors/raw/main/filter-plugin/logstash-filter-mariadb-guardium/MariaDB.conf) file's input part, omitting the keyword "input{" at the beginning and its corresponding "}" at the end.

--- a/filter-plugin/logstash-filter-mssql-guardium/README.md
+++ b/filter-plugin/logstash-filter-mssql-guardium/README.md
@@ -214,14 +214,14 @@ The Guardium universal connector is the Guardium entry point for native audit lo
 * Configure the policies you require. See [policies](/docs/#policies) for more information.
 * You must have permission for the S-Tap Management role. The admin user includes this role by default.
 * Download the [mssql-offline-plugins-7.5.2.zip](https://github.com/IBM/universal-connectors/raw/main/filter-plugin/logstash-filter-mssql-guardium/MssqlOverJdbcPackage/mssql-offline-plugins-7.5.2.zip) plug-in.
-* Download the [logstash-filter-xml.zip](https://github.com/IBM/universal-connectors/raw/main/filter-plugin/logstash-filter-mssql-guardium/MssqlOverJdbcPackage/logstash-filter-xml.zip) plug-in.[This zip is not required for AWS MSSQL]
+* Download the [logstash-filter-xml.zip](https://github.com/IBM/universal-connectors/raw/main/filter-plugin/logstash-filter-mssql-guardium/MssqlOverJdbcPackage/logstash-filter-xml.zip) plug-in.[This zip is not required for AWS MSSQL]. This is not necessary for Guardium Data Protection v12.0 and later.
 * Download the [mssql-jdbc-7.4.1.jre8](https://jar-download.com/artifacts/com.microsoft.sqlserver/mssql-jdbc/7.4.1.jre8) jar.
 
 #### Procedure:
 
 1. On the collector, go to Setup > Tools and Views > Configure Universal Connector.
 2. First Enable the Universal Guardium connector, if it is Disabled already.
-3. Click Upload File and select the offline [mssql-offline-plugins-7.5.2.zip](https://github.com/IBM/universal-connectors/raw/main/filter-plugin/logstash-filter-mssql-guardium/MssqlOverJdbcPackage/mssql-offline-plugins-7.5.2.zip) plug-in. After it is uploaded, click OK.
+3. Click Upload File and select the offline [mssql-offline-plugins-7.5.2.zip](https://github.com/IBM/universal-connectors/raw/main/filter-plugin/logstash-filter-mssql-guardium/MssqlOverJdbcPackage/mssql-offline-plugins-7.5.2.zip) plug-in. After it is uploaded, click OK. This is not necessary for Guardium Data Protection v12.0 and later.
 4. Click Upload File and select the offline [logstash-filter-xml.zip](https://github.com/IBM/universal-connectors/raw/main/filter-plugin/logstash-filter-mssql-guardium/MssqlOverJdbcPackage/logstash-filter-xml.zip) plug-in. After it is uploaded, click OK.
 5. Click Upload File and select the [mssql-jdbc-7.4.1.jre8](https://jar-download.com/artifacts/com.microsoft.sqlserver/mssql-jdbc/7.4.1.jre8) jar. After it is uploaded, click OK.
 

--- a/filter-plugin/logstash-filter-mysql-aws-guardium/README.md
+++ b/filter-plugin/logstash-filter-mysql-aws-guardium/README.md
@@ -47,7 +47,7 @@ The 'rdsadmin' user queries the database every second to check its health. This 
 ## Configuring the AWS MySQL filters in Guardium
 ### Before you begin
 • You must have permissions for the S-TAP Management role. The admin user includes this role by default.
-• Download the json-encode-offline-plugin.zip plug-in. **This is not necessary for Guardium Data Protection v12.0 and later**.
+• Download the json-encode-offline-plugin.zip plug-in. This is not necessary for Guardium Data Protection v12.0 and later.
 ## Authorizing outgoing traffic from AWS to Guardium
 1. Log in to the Guardium API.
 2. Issue these commands:
@@ -55,7 +55,7 @@ The 'rdsadmin' user queries the database every second to check its health. This 
 		• grdapi add_domain_to_universal_connector_allowed_domains domain=amazon.com
 ## Procedure
 1. On the collector, go to Setup > Tools and Views > Configure Universal Connector.
-2. Click Upload File and select the [offline json-encode-offline-plugin.zip](https://github.com/IBM/universal-connectors/raw/main/filter-plugin/logstash-filter-mysql-aws-guardium/json-encode-offline-plugin.zip) plug-in. After it is uploaded, click OK. **This is not necessary for Guardium Data Protection v12.0 and later**.
+2. Click Upload File and select the [offline json-encode-offline-plugin.zip](https://github.com/IBM/universal-connectors/raw/main/filter-plugin/logstash-filter-mysql-aws-guardium/json-encode-offline-plugin.zip) plug-in. After it is uploaded, click OK. This is not necessary for Guardium Data Protection v12.0 and later.
 3. Click the Plus sign to open the Connector Configuration dialog box.
 4. Type a name in the Connector name field.
 5. Update the input section to add the details from the [mysqlCloudwatch.conf](https://github.com/IBM/universal-connectors/raw/main/filter-plugin/logstash-filter-mysql-aws-guardium/mysqlCloudwatch.conf) file input section, omitting the keyword "input{" at the beginning and its corresponding "}" at the end.

--- a/filter-plugin/logstash-filter-mysql-aws-guardium/README.md
+++ b/filter-plugin/logstash-filter-mysql-aws-guardium/README.md
@@ -47,7 +47,7 @@ The 'rdsadmin' user queries the database every second to check its health. This 
 ## Configuring the AWS MySQL filters in Guardium
 ### Before you begin
 • You must have permissions for the S-TAP Management role. The admin user includes this role by default.
-• Download the json-encode-offline-plugin.zip plug-in.
+• Download the json-encode-offline-plugin.zip plug-in. **This is not necessary for Guardium Data Protection v12.0 and later**.
 ## Authorizing outgoing traffic from AWS to Guardium
 1. Log in to the Guardium API.
 2. Issue these commands:
@@ -55,7 +55,7 @@ The 'rdsadmin' user queries the database every second to check its health. This 
 		• grdapi add_domain_to_universal_connector_allowed_domains domain=amazon.com
 ## Procedure
 1. On the collector, go to Setup > Tools and Views > Configure Universal Connector.
-2. Click Upload File and select the [offline json-encode-offline-plugin.zip](https://github.com/IBM/universal-connectors/raw/main/filter-plugin/logstash-filter-mysql-aws-guardium/json-encode-offline-plugin.zip) plug-in. After it is uploaded, click OK.
+2. Click Upload File and select the [offline json-encode-offline-plugin.zip](https://github.com/IBM/universal-connectors/raw/main/filter-plugin/logstash-filter-mysql-aws-guardium/json-encode-offline-plugin.zip) plug-in. After it is uploaded, click OK. **This is not necessary for Guardium Data Protection v12.0 and later**.
 3. Click the Plus sign to open the Connector Configuration dialog box.
 4. Type a name in the Connector name field.
 5. Update the input section to add the details from the [mysqlCloudwatch.conf](https://github.com/IBM/universal-connectors/raw/main/filter-plugin/logstash-filter-mysql-aws-guardium/mysqlCloudwatch.conf) file input section, omitting the keyword "input{" at the beginning and its corresponding "}" at the end.

--- a/filter-plugin/logstash-filter-neo4j-guardium/README.md
+++ b/filter-plugin/logstash-filter-neo4j-guardium/README.md
@@ -122,13 +122,13 @@ The Guardium universal connector is the Guardium entry point for native audit lo
 
 • You must have permission for the S-Tap Management role. The admin user includes this role, by default.
 
-• Download the [neo4j-logstash-offline-plugins-7.16.3.zip](https://github.com/IBM/universal-connectors/raw/main/filter-plugin/logstash-filter-neo4j-guardium/NeodbOverFilebeatPackage/Neo4jDB/neo4j-logstash-offline-plugins-7.16.3.zip) plug-in.
+• Download the [neo4j-logstash-offline-plugins-7.16.3.zip](https://github.com/IBM/universal-connectors/raw/main/filter-plugin/logstash-filter-neo4j-guardium/NeodbOverFilebeatPackage/Neo4jDB/neo4j-logstash-offline-plugins-7.16.3.zip) plug-in. This is not necessary for Guardium Data Protection v12.0 and later.
 
 # Procedure
 
 1. On the collector, go to Setup > Tools and Views > Configure Universal Connector.
 2. First enable the Universal Guardium connector, if it is disabled already.
-3. Click Upload File and select the offline [neo4j-logstash-offline-plugins-7.16.3.zip](https://github.com/IBM/universal-connectors/raw/main/filter-plugin/logstash-filter-neo4j-guardium/NeodbOverFilebeatPackage/Neo4jDB/neo4j-logstash-offline-plugins-7.16.3.zip) plug-in. After it is uploaded, click OK.
+3. Click Upload File and select the offline [neo4j-logstash-offline-plugins-7.16.3.zip](https://github.com/IBM/universal-connectors/raw/main/filter-plugin/logstash-filter-neo4j-guardium/NeodbOverFilebeatPackage/Neo4jDB/neo4j-logstash-offline-plugins-7.16.3.zip) plug-in. After it is uploaded, click OK. This is not necessary for Guardium Data Protection v12.0 and later.
 4. Click the Plus sign to open the Connector Configuration dialog box.
 5. Type a name in the Connector name field.
 6. Update the input section to add the details from the [neo4jFilebeat.conf](https://github.com/IBM/universal-connectors/raw/main/filter-plugin/logstash-filter-neo4j-guardium/neo4jFilebeat.conf) file input section, omitting the keyword "input{" at the beginning and its corresponding "}" at the end.

--- a/filter-plugin/logstash-filter-neptune-aws-guardium/README.md
+++ b/filter-plugin/logstash-filter-neptune-aws-guardium/README.md
@@ -114,14 +114,14 @@ The Guardium universal connector is the Guardium entry point for native audit lo
 
 * You must have permission for the S-Tap Management role. The admin user includes this role by  default.
 
-* Download the [guardium_logstash-offline-plugin-neptune.zip plug-in](https://github.com/IBM/universal-connectors/raw/main/filter-plugin/logstash-filter-neptune-aws-guardium/NeptuneOverCloudWatchPackage/Neptune/guardium_logstash-offline-plugin-neptune.zip).
+* Download the [guardium_logstash-offline-plugin-neptune.zip plug-in](https://github.com/IBM/universal-connectors/raw/main/filter-plugin/logstash-filter-neptune-aws-guardium/NeptuneOverCloudWatchPackage/Neptune/guardium_logstash-offline-plugin-neptune.zip). This is not necessary for Guardium Data Protection v12.0 and later.
 
 
 #### Procedure
 
  1. On the collector, go to Setup > Tools and Views > Configure Universal Connector.
  2. Enable the connector if it is already disabled, before uploading the UC.
- 3. Click Upload File and select the offline [guardium_logstash-offline-plugin-neptune.zip](https://github.com/IBM/universal-connectors/raw/main/filter-plugin/logstash-filter-neptune-aws-guardium/NeptuneOverCloudWatchPackage/Neptune/guardium_logstash-offline-plugin-neptune.zip) plug-in. After it is uploaded, click OK.
+ 3. Click Upload File and select the offline [guardium_logstash-offline-plugin-neptune.zip](https://github.com/IBM/universal-connectors/raw/main/filter-plugin/logstash-filter-neptune-aws-guardium/NeptuneOverCloudWatchPackage/Neptune/guardium_logstash-offline-plugin-neptune.zip) plug-in. After it is uploaded, click OK. This is not necessary for Guardium Data Protection v12.0 and later.
  4. Click the Plus icon to open the Connector Configuration dialog box.
  5. Type a name in the Connector name field.
  6. Update the input section to add the details from [Neptune.conf](https://github.com/IBM/universal-connectors/raw/main/filter-plugin/logstash-filter-neptune-aws-guardium/neptune.conf) file's input  part, omitting the keyword "input{" at the beginning and its corresponding "}" at the end.

--- a/filter-plugin/logstash-filter-onPremGreenplumdb-guardium/README.md
+++ b/filter-plugin/logstash-filter-onPremGreenplumdb-guardium/README.md
@@ -255,13 +255,13 @@ The Guardium universal connector is the Guardium entry point for native audit lo
 
 *  Configure the policies you require. See [policies](/docs/#policies) for more information.
 * You must have permission for the S-Tap Management role.The admin user includes this role by default.
-* Download the [guardium_logstash-offline-plugin-greenplumdb.zip](https://github.com/IBM/universal-connectors/raw/main/filter-plugin/logstash-filter-onPremGreenplumdb-guardium/GreenplumdbOverFilebeatPackage/GreenPlumDB/guardium_logstash-offline-plugin-greenplumdb.zip) plug-in file.
+* Download the [guardium_logstash-offline-plugin-greenplumdb.zip](https://github.com/IBM/universal-connectors/raw/main/filter-plugin/logstash-filter-onPremGreenplumdb-guardium/GreenplumdbOverFilebeatPackage/GreenPlumDB/guardium_logstash-offline-plugin-greenplumdb.zip) plug-in file. This is not necessary for Guardium Data Protection v12.0 and later.
 
 
 ### Procedure
 1. On the collector, go to Setup > Tools and Views > Configure Universal Connector.
 2. Enable the connector if it is already disabled, before uploading the UC.
-3. Click Upload File and select the offline [guardium_logstash-offline-plugin-greenplumdb.zip](https://github.com/IBM/universal-connectors/raw/main/filter-plugin/logstash-filter-onPremGreenplumdb-guardium/GreenplumdbOverFilebeatPackage/GreenPlumDB/guardium_logstash-offline-plugin-greenplumdb.zip) plug-in. After it is uploaded, click OK.
+3. Click Upload File and select the offline [guardium_logstash-offline-plugin-greenplumdb.zip](https://github.com/IBM/universal-connectors/raw/main/filter-plugin/logstash-filter-onPremGreenplumdb-guardium/GreenplumdbOverFilebeatPackage/GreenPlumDB/guardium_logstash-offline-plugin-greenplumdb.zip) plug-in. After it is uploaded, click OK. This is not necessary for Guardium Data Protection v12.0 and later.
 4. Click the Plus icon to open the Connector Configuration dialog box.
 5. Type a name in the Connector name field.
 6. Update the input section to add the details from the [greenplumdb.conf](https://github.com/IBM/universal-connectors/raw/main/filter-plugin/logstash-filter-onPremGreenplumdb-guardium/greenplumdb.conf) file's input part, omitting the keyword "input{" at the beginning and its corresponding "}" at the end.

--- a/filter-plugin/logstash-filter-onPremPostgres-guardium/EDBPostgres_README.md
+++ b/filter-plugin/logstash-filter-onPremPostgres-guardium/EDBPostgres_README.md
@@ -113,12 +113,12 @@ The Guardium universal connector is the Guardium entry point for native audit lo
 
 • You must have permission for the S-Tap Management role. The admin user includes this role, by default.
 
-• Download the [postgres-offline-plugins-7.5.2.zip](https://github.com/IBM/universal-connectors/raw/main/filter-plugin/logstash-filter-onPremPostgres-guardium/PostgresOverFilebeatPackage/postgres-offline-plugins-7.5.2.zip) plug-in
+• Download the [postgres-offline-plugins-7.5.2.zip](https://github.com/IBM/universal-connectors/raw/main/filter-plugin/logstash-filter-onPremPostgres-guardium/PostgresOverFilebeatPackage/postgres-offline-plugins-7.5.2.zip) plug-in. This is not necessary for Guardium Data Protection v12.0 and later.
 
 ### Procedure
 1. On the collector, go to Setup > Tools and Views > Configure Universal Connector.
 2. First enable the Universal Guardium connector, if it is disabled already.
-3. Click Upload File and select the offline  [postgres-offline-plugins-7.5.2.zip](https://github.com/IBM/universal-connectors/raw/main/filter-plugin/logstash-filter-onPremPostgres-guardium/PostgresOverFilebeatPackage/postgres-offline-plugins-7.5.2.zip)  plug-in. After it is uploaded, click OK.
+3. Click Upload File and select the offline  [postgres-offline-plugins-7.5.2.zip](https://github.com/IBM/universal-connectors/raw/main/filter-plugin/logstash-filter-onPremPostgres-guardium/PostgresOverFilebeatPackage/postgres-offline-plugins-7.5.2.zip)  plug-in. After it is uploaded, click OK. This is not necessary for Guardium Data Protection v12.0 and later.
 4. Click the Plus sign to open the Connector Configuration dialog box.
 5. Type a name in the Connector name field.
 6. Update the input section to add the details from the [PostgresFilebeat.conf](https://github.com/IBM/universal-connectors/raw/main/filter-plugin/logstash-filter-onPremPostgres-guardium/PostgresFilebeat.conf) file's input part, omitting the keyword "input{" at the beginning and its corresponding "}" at the end.

--- a/filter-plugin/logstash-filter-onPremPostgres-guardium/FEPostgres_README.md
+++ b/filter-plugin/logstash-filter-onPremPostgres-guardium/FEPostgres_README.md
@@ -119,12 +119,12 @@ The Guardium universal connector is the Guardium entry point for native audit lo
 
 • You must have permission for the S-Tap Management role. The admin user includes this role, by default.
 					 
-• Download the [postgres-offline-plugins-7.5.2.zip](https://github.com/IBM/universal-connectors/raw/main/filter-plugin/logstash-filter-onPremPostgres-guardium/PostgresOverFilebeatPackage/postgres-offline-plugins-7.5.2.zip) plug-in
+• Download the [postgres-offline-plugins-7.5.2.zip](https://github.com/IBM/universal-connectors/raw/main/filter-plugin/logstash-filter-onPremPostgres-guardium/PostgresOverFilebeatPackage/postgres-offline-plugins-7.5.2.zip) plug-in. This is not necessary for Guardium Data Protection v12.0 and later.
 
 # Procedure
 1. On the collector, go to Setup > Tools and Views > Configure Universal Connector.
 2. First enable the Universal Guardium connector, if it is disabled already.
-3. Click Upload File and select the offline [postgres-offline-plugins-7.5.2.zip](https://github.com/IBM/universal-connectors/raw/main/filter-plugin/logstash-filter-onPremPostgres-guardium/PostgresOverFilebeatPackage/postgres-offline-plugins-7.5.2.zip)  plug-in. After it is uploaded, click OK.
+3. Click Upload File and select the offline [postgres-offline-plugins-7.5.2.zip](https://github.com/IBM/universal-connectors/raw/main/filter-plugin/logstash-filter-onPremPostgres-guardium/PostgresOverFilebeatPackage/postgres-offline-plugins-7.5.2.zip)  plug-in. After it is uploaded, click OK. This is not necessary for Guardium Data Protection v12.0 and later.
 4. Click the Plus sign to open the Connector Configuration dialog box.
 5. Type a name in the Connector name field.
 6. Update the input section to add the details from the [PostgresFilebeat.conf](https://github.com/IBM/universal-connectors/raw/main/filter-plugin/logstash-filter-onPremPostgres-guardium/PostgresFilebeat.conf) file's input part, omitting the keyword "input{" at the beginning and its corresponding "}" at the end.

--- a/filter-plugin/logstash-filter-postgres-guardium/AuroraPostgres_README.md
+++ b/filter-plugin/logstash-filter-postgres-guardium/AuroraPostgres_README.md
@@ -188,13 +188,13 @@ The Guardium universal connector is the Guardium entry point for native audit lo
 
 • You must have permission for the S-Tap Management role. The admin user includes this role by default.
 
-• Download the [postgres-offline-plugins-7.5.2.zip plug-in.](https://github.com/IBM/universal-connectors/raw/main/filter-plugin/logstash-filter-postgres-guardium/PostgresOverCloudWatchPackage/Postgres/postgres-offline-plugins-7.5.2.zip)
+• Download the [postgres-offline-plugins-7.5.2.zip plug-in.](https://github.com/IBM/universal-connectors/raw/main/filter-plugin/logstash-filter-postgres-guardium/PostgresOverCloudWatchPackage/Postgres/postgres-offline-plugins-7.5.2.zip) **This is not necessary for Guardium Data Protection v12.0 and later**.
 
 #### Procedure
 
 1. On the collector, go to Setup > Tools and Views > Configure Universal Connector.
 2. First enable the Universal Guardium connector, if it is disabled already.
-3. Click Upload File and select the [offline postgres-offline-plugins-7.5.2.zip](https://github.com/IBM/universal-connectors/raw/main/filter-plugin/logstash-filter-postgres-guardium/PostgresOverCloudWatchPackage/Postgres/postgres-offline-plugins-7.5.2.zip) plug-in. After it is uploaded, click OK.
+3. Click Upload File and select the [offline postgres-offline-plugins-7.5.2.zip](https://github.com/IBM/universal-connectors/raw/main/filter-plugin/logstash-filter-postgres-guardium/PostgresOverCloudWatchPackage/Postgres/postgres-offline-plugins-7.5.2.zip) plug-in. After it is uploaded, click OK. **This is not necessary for Guardium Data Protection v12.0 and later**.
 4. Click the Plus sign to open the Connector Configuration dialog box.
 5. Type a name in the Connector name field.
 6. Update the input section to add the details from the [postgresCloudwatch.conf](https://github.com/IBM/universal-connectors/raw/main/filter-plugin/logstash-filter-postgres-guardium/postgresCloudwatch.conf)  file's input part, omitting the keyword "input{" at the beginning and its corresponding "}" at the end.

--- a/filter-plugin/logstash-filter-postgres-guardium/AuroraPostgres_README.md
+++ b/filter-plugin/logstash-filter-postgres-guardium/AuroraPostgres_README.md
@@ -188,13 +188,13 @@ The Guardium universal connector is the Guardium entry point for native audit lo
 
 • You must have permission for the S-Tap Management role. The admin user includes this role by default.
 
-• Download the [postgres-offline-plugins-7.5.2.zip plug-in.](https://github.com/IBM/universal-connectors/raw/main/filter-plugin/logstash-filter-postgres-guardium/PostgresOverCloudWatchPackage/Postgres/postgres-offline-plugins-7.5.2.zip) **This is not necessary for Guardium Data Protection v12.0 and later**.
+• Download the [postgres-offline-plugins-7.5.2.zip plug-in.](https://github.com/IBM/universal-connectors/raw/main/filter-plugin/logstash-filter-postgres-guardium/PostgresOverCloudWatchPackage/Postgres/postgres-offline-plugins-7.5.2.zip) This is not necessary for Guardium Data Protection v12.0 and later.
 
 #### Procedure
 
 1. On the collector, go to Setup > Tools and Views > Configure Universal Connector.
 2. First enable the Universal Guardium connector, if it is disabled already.
-3. Click Upload File and select the [offline postgres-offline-plugins-7.5.2.zip](https://github.com/IBM/universal-connectors/raw/main/filter-plugin/logstash-filter-postgres-guardium/PostgresOverCloudWatchPackage/Postgres/postgres-offline-plugins-7.5.2.zip) plug-in. After it is uploaded, click OK. **This is not necessary for Guardium Data Protection v12.0 and later**.
+3. Click Upload File and select the [offline postgres-offline-plugins-7.5.2.zip](https://github.com/IBM/universal-connectors/raw/main/filter-plugin/logstash-filter-postgres-guardium/PostgresOverCloudWatchPackage/Postgres/postgres-offline-plugins-7.5.2.zip) plug-in. After it is uploaded, click OK. This is not necessary for Guardium Data Protection v12.0 and later.
 4. Click the Plus sign to open the Connector Configuration dialog box.
 5. Type a name in the Connector name field.
 6. Update the input section to add the details from the [postgresCloudwatch.conf](https://github.com/IBM/universal-connectors/raw/main/filter-plugin/logstash-filter-postgres-guardium/postgresCloudwatch.conf)  file's input part, omitting the keyword "input{" at the beginning and its corresponding "}" at the end.

--- a/filter-plugin/logstash-filter-postgres-guardium/AwsPostgres_README.md
+++ b/filter-plugin/logstash-filter-postgres-guardium/AwsPostgres_README.md
@@ -188,13 +188,13 @@ The Guardium universal connector is the Guardium entry point for native audit lo
 
 • You must have permission for the S-Tap Management role. The admin user includes this role by default.
 
-• Download the [postgres-offline-plugins-7.5.2.zip plug-in.](https://github.com/IBM/universal-connectors/raw/main/filter-plugin/logstash-filter-postgres-guardium/PostgresOverCloudWatchPackage/Postgres/postgres-offline-plugins-7.5.2.zip)
+• Download the [postgres-offline-plugins-7.5.2.zip plug-in.](https://github.com/IBM/universal-connectors/raw/main/filter-plugin/logstash-filter-postgres-guardium/PostgresOverCloudWatchPackage/Postgres/postgres-offline-plugins-7.5.2.zip) **This is not necessary for Guardium Data Protection v12.0 and later**.
 
 #### Procedure
 
 1. On the collector, go to Setup > Tools and Views > Configure Universal Connector.
 2. First enable the Universal Guardium connector, if it is disabled already.
-3. Click Upload File and select the [offline postgres-offline-plugins-7.5.2.zip](https://github.com/IBM/universal-connectors/raw/main/filter-plugin/logstash-filter-postgres-guardium/PostgresOverCloudWatchPackage/Postgres/postgres-offline-plugins-7.5.2.zip) plug-in. After it is uploaded, click OK.
+3. Click Upload File and select the [offline postgres-offline-plugins-7.5.2.zip](https://github.com/IBM/universal-connectors/raw/main/filter-plugin/logstash-filter-postgres-guardium/PostgresOverCloudWatchPackage/Postgres/postgres-offline-plugins-7.5.2.zip) plug-in. After it is uploaded, click OK. **This is not necessary for Guardium Data Protection v12.0 and later**.
 4. Click the Plus sign to open the Connector Configuration dialog box.
 5. Type a name in the Connector name field.
 6. Update the input section to add the details from the [postgresCloudwatch.conf](https://github.com/IBM/universal-connectors/raw/main/filter-plugin/logstash-filter-postgres-guardium/postgresCloudwatch.conf)  file's input part, omitting the keyword "input{" at the beginning and its corresponding "}" at the end.

--- a/filter-plugin/logstash-filter-postgres-guardium/AwsPostgres_README.md
+++ b/filter-plugin/logstash-filter-postgres-guardium/AwsPostgres_README.md
@@ -188,13 +188,13 @@ The Guardium universal connector is the Guardium entry point for native audit lo
 
 • You must have permission for the S-Tap Management role. The admin user includes this role by default.
 
-• Download the [postgres-offline-plugins-7.5.2.zip plug-in.](https://github.com/IBM/universal-connectors/raw/main/filter-plugin/logstash-filter-postgres-guardium/PostgresOverCloudWatchPackage/Postgres/postgres-offline-plugins-7.5.2.zip) **This is not necessary for Guardium Data Protection v12.0 and later**.
+• Download the [postgres-offline-plugins-7.5.2.zip plug-in.](https://github.com/IBM/universal-connectors/raw/main/filter-plugin/logstash-filter-postgres-guardium/PostgresOverCloudWatchPackage/Postgres/postgres-offline-plugins-7.5.2.zip) This is not necessary for Guardium Data Protection v12.0 and later.
 
 #### Procedure
 
 1. On the collector, go to Setup > Tools and Views > Configure Universal Connector.
 2. First enable the Universal Guardium connector, if it is disabled already.
-3. Click Upload File and select the [offline postgres-offline-plugins-7.5.2.zip](https://github.com/IBM/universal-connectors/raw/main/filter-plugin/logstash-filter-postgres-guardium/PostgresOverCloudWatchPackage/Postgres/postgres-offline-plugins-7.5.2.zip) plug-in. After it is uploaded, click OK. **This is not necessary for Guardium Data Protection v12.0 and later**.
+3. Click Upload File and select the [offline postgres-offline-plugins-7.5.2.zip](https://github.com/IBM/universal-connectors/raw/main/filter-plugin/logstash-filter-postgres-guardium/PostgresOverCloudWatchPackage/Postgres/postgres-offline-plugins-7.5.2.zip) plug-in. After it is uploaded, click OK. This is not necessary for Guardium Data Protection v12.0 and later.
 4. Click the Plus sign to open the Connector Configuration dialog box.
 5. Type a name in the Connector name field.
 6. Update the input section to add the details from the [postgresCloudwatch.conf](https://github.com/IBM/universal-connectors/raw/main/filter-plugin/logstash-filter-postgres-guardium/postgresCloudwatch.conf)  file's input part, omitting the keyword "input{" at the beginning and its corresponding "}" at the end.

--- a/filter-plugin/logstash-filter-progressdb-guardium/README.md
+++ b/filter-plugin/logstash-filter-progressdb-guardium/README.md
@@ -194,7 +194,7 @@ the native audit logs by customizing the Progress template.
 
 • You must have permission for the S-Tap Management role. The admin user includes this role by default.
 
-• Download the [logstash-filter-progress_guardium_plugin_filter.zip](https://github.ibm.com/Activity-Insights/universal-connectors/raw/master/filter-plugin/logstash-filter-progressdb-guardium/ProgressOverJdbcPackage/logstash-filter-progress_guardium_plugin_filter.zip) file.
+• Download the [logstash-filter-progress_guardium_plugin_filter.zip](https://github.ibm.com/Activity-Insights/universal-connectors/raw/master/filter-plugin/logstash-filter-progressdb-guardium/ProgressOverJdbcPackage/logstash-filter-progress_guardium_plugin_filter.zip) file. This is not necessary for Guardium Data Protection v12.0 and later.
 
 • Download the `openedge.jar` file based on your platform and database version.
 
@@ -207,7 +207,7 @@ the native audit logs by customizing the Progress template.
 
 3. Click **Upload File** and upload the `openedge.jar` file that is included in the enterprise version. 
 
-4. Click **Upload File** and select the offline [logstash-filter-progress_guardium_plugin_filter.zip](https://github.ibm.com/Activity-Insights/universal-connectors/raw/master/filter-plugin/logstash-filter-progressdb-guardium/ProgressOverJdbcPackage/logstash-filter-progress_guardium_plugin_filter.zip) file. After it is uploaded, click **OK**.
+4. Click **Upload File** and select the offline [logstash-filter-progress_guardium_plugin_filter.zip](https://github.ibm.com/Activity-Insights/universal-connectors/raw/master/filter-plugin/logstash-filter-progressdb-guardium/ProgressOverJdbcPackage/logstash-filter-progress_guardium_plugin_filter.zip) file. After it is uploaded, click **OK**. This is not necessary for Guardium Data Protection v12.0 and later.
 
 5. Click the Plus icon to open the Connector Configuration dialog box.
     

--- a/filter-plugin/logstash-filter-pubsub-apachesolr-guardium/README.md
+++ b/filter-plugin/logstash-filter-pubsub-apachesolr-guardium/README.md
@@ -241,12 +241,12 @@ The Guardium universal connector is the Guardium entry point for native audit/da
 ## Before you begin
 *  Configure the policies you require. See [policies](/docs/#policies) for more information.
 * You must have permission for the S-Tap Management role. The admin user includes this role by default.
-* Download the [guardium_logstash-offline-plugin-pubsub-apache-solr-gcp.zip](PubSubApacheSolrPackage/guardium_logstash-offline-plugin-pubsub-apache-solr-gcp.zip) plug-in.
+* Download the [guardium_logstash-offline-plugin-pubsub-apache-solr-gcp.zip](PubSubApacheSolrPackage/guardium_logstash-offline-plugin-pubsub-apache-solr-gcp.zip) plug-in. This is not necessary for Guardium Data Protection v12.0 and later.
 
 ## Procedure
 1. On the collector, go to Setup > Tools and Views > Configure Universal Connector.
 2. Enable the connector if it is disabled before uploading the UC plug-in.
-3. Click Upload File and select the offline [guardium_logstash-offline-plugin-pubsub-apache-solr-gcp.zip](PubSubApacheSolrPackage/guardium_logstash-offline-plugin-pubsub-apache-solr-gcp.zip) plug-in. After it is uploaded, click OK.
+3. Click Upload File and select the offline [guardium_logstash-offline-plugin-pubsub-apache-solr-gcp.zip](PubSubApacheSolrPackage/guardium_logstash-offline-plugin-pubsub-apache-solr-gcp.zip) plug-in. After it is uploaded, click OK. This is not necessary for Guardium Data Protection v12.0 and later.
 4. Click Upload File and select the key.json file(which was generated above for the service account). After it is uploaded, click OK.
 5. Click the Plus sign to open the Connector Configuration dialog box.
 6. Type a name in the Connector name field.

--- a/filter-plugin/logstash-filter-pubsub-bigquery-guardium/README.md
+++ b/filter-plugin/logstash-filter-pubsub-bigquery-guardium/README.md
@@ -137,12 +137,12 @@ The Guardium universal connector is the Guardium entry point for native audit/da
 ### Before you begin
 * Configure the policies you require. See [policies](/docs/#policies) for more information.
 * You must have permission for the S-Tap Management role. The admin user includes this role by default
-* Download the [guardium_logstash-offline-plugins-ps-bigQuery.zip](BigQueryOverPubSubPackage/guardium_logstash-offline-plugins-ps-bigQuery.zip) plug-in.
+* Download the [guardium_logstash-offline-plugins-ps-bigQuery.zip](BigQueryOverPubSubPackage/guardium_logstash-offline-plugins-ps-bigQuery.zip) plug-in. This is not necessary for Guardium Data Protection v12.0 and later.
 
 ### Procedure
 1. On the collector, go to Setup > Tools and Views > Configure Universal Connector.
 2. Enable the connector if it is disabled before uploading the UC plug-in.
-3. Click Upload File and select the offline [guardium_logstash-offline-plugins-ps-bigQuery.zip](BigQueryOverPubSubPackage/guardium_logstash-offline-plugins-ps-bigQuery.zip) plug-in. After it is uploaded, click ```OK```.
+3. Click Upload File and select the offline [guardium_logstash-offline-plugins-ps-bigQuery.zip](BigQueryOverPubSubPackage/guardium_logstash-offline-plugins-ps-bigQuery.zip) plug-in. After it is uploaded, click ```OK```. This is not necessary for Guardium Data Protection v12.0 and later.
 4. Click ```Upload File``` and select the key.json file. After it is uploaded, click ```OK```.
 5. Click the Plus sign to open the Connector Configuration dialog box.
 6. Type a name in the Connector name field.

--- a/filter-plugin/logstash-filter-pubsub-firestore-guardium/README.md
+++ b/filter-plugin/logstash-filter-pubsub-firestore-guardium/README.md
@@ -131,12 +131,12 @@ The Guardium universal connector is the Guardium entry point for native audit/da
 ### Before you begin
    * Configure the policies you require. See [policies](/docs/#policies) for more information.
    * You must have permission for the S-Tap Management role. The admin user includes this role by default.
-   * Download the [guardium_logstash-offline-plugins-ps-firestore.zip](PubSubFireStorePackage/guardium_logstash-offline-plugins-ps-firestore.zip) plug-in.
+   * Download the [guardium_logstash-offline-plugins-ps-firestore.zip](PubSubFireStorePackage/guardium_logstash-offline-plugins-ps-firestore.zip) plug-in. This is not necessary for Guardium Data Protection v12.0 and later.
 
 ### Procedure
 1. On the collector, go to Setup > Tools and Views > Configure Universal Connector.
 2. First, enable the Universal Guardium connector if it is disabled.
-3. Click Upload File and select the offline [guardium_logstash-offline-plugins-ps-firestore.zip](PubSubFireStorePackage/guardium_logstash-offline-plugins-ps-firestore.zip) plug-in. After it is uploaded, click OK.
+3. Click Upload File and select the offline [guardium_logstash-offline-plugins-ps-firestore.zip](PubSubFireStorePackage/guardium_logstash-offline-plugins-ps-firestore.zip) plug-in. After it is uploaded, click OK. This is not necessary for Guardium Data Protection v12.0 and later.
 3. Click the plus icon to open the Connector Configuration dialog box.
 4. Type a name in the Connector name field.
 5. Update the input section to add the details from the [firestore_pubsub_run.conf](PubSubFireStorePackage/firestore_pubsub_run.conf) file's input part, omitting the keyword "input{" at the beginning and its corresponding "}" at the end.

--- a/filter-plugin/logstash-filter-pubsub-spanner-guardium/README.md
+++ b/filter-plugin/logstash-filter-pubsub-spanner-guardium/README.md
@@ -130,12 +130,12 @@ The Guardium universal connector is the Guardium entry point for native audit/da
 ### Before you begin
 * Configure the policies you require. See [policies](/docs/#policies) for more information.
 * You must have permission for the S-Tap Management role. The admin user includes this role by default.
-* Download the [guardium_logstash-offline-plugins-gcp-pubsub-spanner.zip](SpannerOverPubSubPackage/guardium_logstash-offline-plugins-gcp-pubsub-spanner.zip) plug-in.
+* Download the [guardium_logstash-offline-plugins-gcp-pubsub-spanner.zip](SpannerOverPubSubPackage/guardium_logstash-offline-plugins-gcp-pubsub-spanner.zip) plug-in. This is not necessary for Guardium Data Protection v12.0 and later.
 
 ### Procedure
 1. On the collector, go to Setup > Tools and Views > Configure Universal Connector.
 2. Enable the connector if it is already disabled, before uploading the universal connector.
-3. Click upload File and select the [guardium_logstash-offline-plugins-gcp-pubsub-spanner.zip](SpannerOverPubSubPackage/guardium_logstash-offline-plugins-gcp-pubsub-spanner.zip) plug-in. After it is uploaded, click OK.
+3. Click upload File and select the [guardium_logstash-offline-plugins-gcp-pubsub-spanner.zip](SpannerOverPubSubPackage/guardium_logstash-offline-plugins-gcp-pubsub-spanner.zip) plug-in. After it is uploaded, click OK. This is not necessary for Guardium Data Protection v12.0 and later.
 4. Click Upload File and select the key.json file. After it is uploaded, click OK.
 5. Click the Plus sign to open the Connector Configuration dialog box.
 6. Type a name in the Connector name field.

--- a/filter-plugin/logstash-filter-redshift-aws-guardium/README.md
+++ b/filter-plugin/logstash-filter-redshift-aws-guardium/README.md
@@ -90,12 +90,12 @@ grdapi add_domain_to_universal_connector_allowed_domains domain=amazonaws.com
 *  Configure the policies you require. See [policies](/docs/#policies) for more information.
 * You must have permission for the S-Tap Management role. The admin user includes this role by default.
 * Download the [logstash-filter-redshift_guardium_connector.zip](https://github.com/IBM/universal-connectors/raw/main/filter-plugin/logstash-filter-redshift-aws-guardium/S3OverRedshiftPackage/logstash-filter-redshift_guardium_connector.zip) plug-in.
-* Download the plugin filter configuration file [redshift.conf](https://github.com/IBM/universal-connectors/raw/main/filter-plugin/logstash-filter-redshift-aws-guardium/redshift.conf).
+* Download the plugin filter configuration file [redshift.conf](https://github.com/IBM/universal-connectors/raw/main/filter-plugin/logstash-filter-redshift-aws-guardium/redshift.conf). This is not necessary for Guardium Data Protection v12.0 and later.
 
 ## Procedure
 1. On the collector, go to Setup > Tools and Views > Configure Universal Connector.
 2. Enable the connector if it is already disabled, before proceeding to upload the UC.
-3. Click Upload File and select the [logstash-filter-redshift_guardium_connector.zip](https://github.com/IBM/universal-connectors/raw/main/filter-plugin/logstash-filter-redshift-aws-guardium/S3OverRedshiftPackage/logstash-filter-redshift_guardium_connector.zip) plug-in. After it is uploaded, click OK.
+3. Click Upload File and select the [logstash-filter-redshift_guardium_connector.zip](https://github.com/IBM/universal-connectors/raw/main/filter-plugin/logstash-filter-redshift-aws-guardium/S3OverRedshiftPackage/logstash-filter-redshift_guardium_connector.zip) plug-in. After it is uploaded, click OK. This is not necessary for Guardium Data Protection v12.0 and later.
 4. Click the Plus sign to open the Connector Configuration dialog box.
 5. Type a name in the Connector name field.
 6. Update the input section to add the details from [redshift.conf](https://github.com/IBM/universal-connectors/raw/main/filter-plugin/logstash-filter-redshift-aws-guardium/redshift.conf) file's input part, omitting the keyword "input{" at the beginning and its corresponding "}" at the end.

--- a/filter-plugin/logstash-filter-snowflake-guardium/README.md
+++ b/filter-plugin/logstash-filter-snowflake-guardium/README.md
@@ -87,7 +87,7 @@ you can turn it off. To do this, set the value to `false` for the following two 
 1. Configure the policies you require. See [policies](/docs/#policies) for more information. 
 2. You must have permission for the S-Tap Management role. The admin user includes this role by default.
 3. Download the [logstash-filter-guardium_snowflake_filter-1.0.0.zip](SnowflakeOverJbdcPackage/Snowflake/logstash-offline-plugins-7.12.1.zip)
-plug-in.
+plug-in. This is not necessary for Guardium Data Protection v12.0 and later.
 4. The plugin is tested with Snowflake JDBC driver v3.13.30.
 Download the jdbc driver `jar` file from the maven repository [here](https://repo1.maven.org/maven2/net/snowflake/snowflake-jdbc/).
 
@@ -95,9 +95,9 @@ Download the jdbc driver `jar` file from the maven repository [here](https://rep
 
 1. On the collector, go to `Setup` > `Tools and Views` > `Configure Universal Connector`.
 2. Enable the universal connector if it is disabled.
-3. Click `Upload File` and select the downloaded .jar jdbc driver file. After it is uploaded, click `OK`.
-4. Click `Upload File` and select the offline [logstash-offline-plugins-7.12.1.zip](SnowflakeOverJbdcPackage/Snowflake/logstash-offline-plugins-7.12.1.zip) 
-   plug-in. After it is uploaded, click `OK`.
+3. Click **Upload File** and select the downloaded .jar jdbc driver file. After it is uploaded, click **OK**. 
+4. Click **Upload File** and select the offline [logstash-offline-plugins-7.12.1.zip](SnowflakeOverJbdcPackage/Snowflake/logstash-offline-plugins-7.12.1.zip) 
+   plug-in. After it is uploaded, click **OK**. This is not necessary for Guardium Data Protection v12.0 and later.
 5. Click the Plus sign to open the Connector Configuration dialog box.
 6. Type a name in the `Connector name` field.
 7. Update the input section to add the details from the [snowflakeJDBC.conf](snowflakeJDBC.conf) file input section, 

--- a/filter-plugin/logstash-filter-teradatadb-guardium/README.md
+++ b/filter-plugin/logstash-filter-teradatadb-guardium/README.md
@@ -126,7 +126,7 @@ The Guardium universal connector is the Guardium entry point for native audit lo
 
 • You must have permission for the S-Tap Management role. The admin user includes this role by default.
 
-• Download the [Teradata-Offline-Plugin.zip](https://github.com/IBM/universal-connectors/raw/main/filter-plugin/logstash-filter-teradatadb-guardium/TeradataOverJdbcPackage/Teradata-Offline-Plugin.zip) plug-in.
+• Download the [Teradata-Offline-Plugin.zip](https://github.com/IBM/universal-connectors/raw/main/filter-plugin/logstash-filter-teradatadb-guardium/TeradataOverJdbcPackage/Teradata-Offline-Plugin.zip) plug-in. This is not necessary for Guardium Data Protection v12.0 and later.
 
 • Download the required jars as per your database version from URL:- https://downloads.teradata.com/download/connectivity/jdbc-driver
 
@@ -141,7 +141,7 @@ The Guardium universal connector is the Guardium entry point for native audit lo
 2. First enable the Universal Guardium connector, if it is disabled already.
 3. Click ```Upload File``` and upload the jar/jars which you downloaded from the teradata website.
 4. Click ```Upload File``` and upload "tdgssconfig.jar".
-5. Click ```Upload File``` and select the offline [Teradata-Offline-Plugin.zip](https://github.com/IBM/universal-connectors/raw/main/filter-plugin/logstash-filter-teradatadb-guardium/TeradataOverJdbcPackage/Teradata-Offline-Plugin.zip) plug-in. After it is uploaded, click ```OK```.
+5. Click ```Upload File``` and select the offline [Teradata-Offline-Plugin.zip](https://github.com/IBM/universal-connectors/raw/main/filter-plugin/logstash-filter-teradatadb-guardium/TeradataOverJdbcPackage/Teradata-Offline-Plugin.zip) plug-in. After it is uploaded, click ```OK```. This is not necessary for Guardium Data Protection v12.0 and later.
 6. Click the Plus sign to open the ```Connector Configuration``` dialog box. 
 7. Type a name in the Connector name field.
 8. Update the input section to add the details from the [teradataJDBC.conf](https://github.com/IBM/universal-connectors/raw/main/filter-plugin/logstash-filter-teradatadb-guardium/TeradataOverJdbcPackage/teradataJDBC.conf) file's input part, omitting the keyword "input{" at the beginning and its corresponding "}" at the end. Provide the details for database server name, username, and password that are required for connecting with JDBC.

--- a/filter-plugin/logstash-filter-yugabyte-guardium/README.md
+++ b/filter-plugin/logstash-filter-yugabyte-guardium/README.md
@@ -132,13 +132,13 @@ When UC will start collecting data, It may show two STAP statuses in the pattern
 
 • Configure the policies you require. See [policies](/docs/#policies) for more information.
 -  You must have permission for the S-Tap Management role. The admin user includes this role by default.
- - Download the [yugabyte-logstash-offline-plugins-1.0.0.zip](https://github.com/IBM/universal-connectors/raw/main/filter-plugin/logstash-filter-yugabyte-guardium/YugabytedbOverFilebeatPackage/YugabyteDB/yugabytedb-logstash-offline-plugins-1.0.0.zip) plug-in.
+ - Download the [yugabyte-logstash-offline-plugins-1.0.0.zip](https://github.com/IBM/universal-connectors/raw/main/filter-plugin/logstash-filter-yugabyte-guardium/YugabytedbOverFilebeatPackage/YugabyteDB/yugabytedb-logstash-offline-plugins-1.0.0.zip) plug-in. This is not necessary for Guardium Data Protection v12.0 and later.
 
 # Procedure
 
 1. On the collector, go to Setup > Tools and Views > Configure Universal Connector.
 2. First enable the Universal Guardium connector if it is disabled.
-3. Click Upload File and select the offline [yugabyte-logstash-offline-plugins-1.0.0.zip](https://github.com/IBM/universal-connectors/raw/main/filter-plugin/logstash-filter-yugabyte-guardium/YugabytedbOverFilebeatPackage/YugabyteDB/yugabytedb-logstash-offline-plugins-1.0.0.zip) plug-in. After it is uploaded, click OK.
+3. Click Upload File and select the offline [yugabyte-logstash-offline-plugins-1.0.0.zip](https://github.com/IBM/universal-connectors/raw/main/filter-plugin/logstash-filter-yugabyte-guardium/YugabytedbOverFilebeatPackage/YugabyteDB/yugabytedb-logstash-offline-plugins-1.0.0.zip) plug-in. After it is uploaded, click OK. This is not necessary for Guardium Data Protection v12.0 and later.
 4. Click the Plus sign to open the Connector Configuration dialog box.
 5. Type a name in the Connector name field.
 6. Update the input section to add the details from the [yugabyteFilebeat.conf](https://github.com/IBM/universal-connectors/raw/main/filter-plugin/logstash-filter-yugabyte-guardium/yugabyteFilebeat.conf) file input section, omitting the keyword "input{" at the beginning and its corresponding "}" at the end.


### PR DESCRIPTION
Update Readme file for all published plugins to mention that plugin upload is now not mandatory in v12

+ 

UC host name includes first connection name, when 2 connections are created in uc configuration page

note:
some plug-in readmes also had a step to upload an additional file (usually a jar file). In those instances, I did not add a note that this step isn't necessary starting v12.0. 

some plug-in readmes had a somewhat different process. (SAP HANA, OUA..) I did not add any note there either.

Please advise if you know what to do in those cases. 