### PR TITLE
Updated Account ID Paramter for DocumentDB

### DIFF
--- a/filter-plugin/logstash-filter-documentdb-aws-guardium/documentDBCloudwatch.conf
+++ b/filter-plugin/logstash-filter-documentdb-aws-guardium/documentDBCloudwatch.conf
@@ -19,13 +19,17 @@ secret_access_key => <SECRET_KEY>
 
 event_filter => ''
 
+#Insert the account id of the AWS account
+add_field => {"account_id" => "<ACCOUNT_ID>"}
+
 type => "docdb"
 }
 }
 filter {
 if [type] == "docdb" {
 mutate {
-replace => { "serverHostnamePrefix" => "<accountId>_%{[cloudwatch_logs][log_stream]}" }
+replace => { "serverHostnamePrefix" => "%{account_id}_%{[cloudwatch_logs][log_stream]}" }
+replace => { "dbnamePrefix" => "%{account_id}:%{[cloudwatch_logs][log_stream]}" }
 replace => { "event_id" => "%{[cloudwatch_logs][event_id]}" }
 }
 documentdb_guardium_filter {}

--- a/input-plugin/logstash-input-cloudwatch-logs/README.md
+++ b/input-plugin/logstash-input-cloudwatch-logs/README.md
@@ -96,6 +96,7 @@ Other standard logstash parameters are available such as:
           what => "previous"
         }
 		type => "test"
+		add_field => {"account_id" => "<Enter the account id>"}
 		add_field => {"abc" => "value"}
 	}
 


### PR DESCRIPTION
For GRD-81136, We've observed that Customers have only updated Input Config and not Filter Config while changing different account.
So inline to Aurora-MySQL Cloudwatch Plugin we've asked for Account_ID in Input Filter.

Output:-

![image](https://media.github.ibm.com/user/458744/files/0a50d8d1-58ae-408a-815c-d03ddcdda1ca)
