### PR TITLE
 [Updating NeptuneDB with newer version of rdf4jQueryparserSparql and tinkergraphGremlin]

### DIFF
--- a/versions.yml
+++ b/versions.yml
@@ -14,5 +14,5 @@ dependencies:
   javaxJson: 1.1.4
   guava: 32.1.3-jre
   commonsText: 1.10.0
-  tinkergraphGremlin: 3.6.4
-  rdf4jQueryparserSparql:  5.0.2
+  tinkergraphGremlin: 3.6.8
+  rdf4jQueryparserSparql:  5.0.3


### PR DESCRIPTION
Updated :

rdf4jQueryparserSparql- From 5.0.2 to 5.0.3
tinkergraphGremlin- From 3.6.4 to 3.6.8