### PR TITLE
GRD-109715 [UC Regression] : Mongo Syslog parser not able to parse me…

### DIFF
--- a/filter-plugin/logstash-filter-mongodb-guardium/MongoDBOverSyslogPackage/MongoDB/filter.conf
+++ b/filter-plugin/logstash-filter-mongodb-guardium/MongoDBOverSyslogPackage/MongoDB/filter.conf
@@ -6,10 +6,11 @@ if [type] == "syslog-mongodb" {
 	}
 
     date {
-      match => [ "timestamp", "MMM  d HH:mm:ss", "MMM dd HH:mm:ss" ]
+      match => [ "syslog_timestamp", "MMM  d HH:mm:ss", "MMM dd HH:mm:ss" ]
 	}
 
     mutate { rename => { "host" => "server_ip" } }
+    mutate { gsub => ["message", "mongod\[\d+\]:", "mongod:"] }
 
 	# send to filter
 	mongodb_guardium_filter {}

--- a/filter-plugin/logstash-filter-mongodb-guardium/MongoDBOverSyslogPackage/mongodbSyslog.conf
+++ b/filter-plugin/logstash-filter-mongodb-guardium/MongoDBOverSyslogPackage/mongodbSyslog.conf
@@ -26,10 +26,11 @@ if [type] == "syslog-mongodb" {
 	}
 
     date {
-      match => [ "timestamp", "MMM  d HH:mm:ss", "MMM dd HH:mm:ss" ]
+      match => [ "syslog_timestamp", "MMM  d HH:mm:ss", "MMM dd HH:mm:ss" ]
 	}
 
     mutate { rename => { "host" => "server_ip" } }
+    mutate { gsub => ["message", "mongod\[\d+\]:", "mongod:"] }
 
 	# send to filter
 	mongodb_guardium_filter {}


### PR DESCRIPTION
…… (#949)

* GRD-109715 [UC Regression] : Mongo Syslog parser not able to parse messages getting error MongodbGuardiumFilter:162 - Message start index was not found and message will be ignored

* GRD-109715 Replicated change to filter.conf

* GRD-109715 Fixed indentation

* GRD-109715 Fixed indentation