### PR TITLE
Update cockroach filter config

### DIFF
--- a/filter-plugin/logstash-filter-cockroachdb-guardium/CockroachDBOverSyslogPackage/CockroachDBOverSyslog.conf
+++ b/filter-plugin/logstash-filter-cockroachdb-guardium/CockroachDBOverSyslogPackage/CockroachDBOverSyslog.conf
@@ -31,14 +31,22 @@ filter {
       drop { }
     }
 
-    # Extract CockroachDB JSON. If the rsyslog template injects server metadata
-    # (serverHostname=<host> serverPort=<port>) as a prefix, extract those too.
-    # See README for rsyslog template configuration.
+    # Extract optional serverHostname and serverPort from the rsyslog template prefix.
+    # Each field is captured independently so a missing field does not affect the other.
+    grok {
+      match => { "message" => ".*serverHostname=%{NOTSPACE:server_hostname}" }
+      tag_on_failure => []
+    }
+    grok {
+      match => { "message" => ".*serverPort=(?<server_port>[^ {\n]+)" }
+      tag_on_failure => []
+    }
+
+    # Extract the CockroachDB JSON payload.
     grok {
       match => {
         "message" => [
-          "serverHostname=%{NOTSPACE:server_hostname} serverPort=(?<server_port>[^ {]+)(?<cockroach_wrapper_json>\{.*\})$",
-          "(?:.*\s)?(?<cockroach_wrapper_json>\{.*\})$"
+          "(?<cockroach_wrapper_json>\{.*\})$"
         ]
       }
     }
@@ -84,16 +92,18 @@ filter {
           }
         }
 
-        # Add ServerHost and ServerPort from rsyslog template prefix if present.
-        # If not present, [host] is left intact so the Java filter can use the
-        # TCP socket IP as a fallback for ServerHost.
+        # Add ServerHost if captured; otherwise [host] remains for the Java filter to use as fallback.
         if [server_hostname] {
           mutate {
-            add_field => {
-              "[cockroachdb][ServerHost]" => "%{server_hostname}"
-              "[cockroachdb][ServerPort]" => "%{server_port}"
-            }
+            add_field => { "[cockroachdb][ServerHost]" => "%{server_hostname}" }
             remove_field => ["host"]
+          }
+        }
+
+        # Add ServerPort if captured.
+        if [server_port] {
+          mutate {
+            add_field => { "[cockroachdb][ServerPort]" => "%{server_port}" }
           }
         }
 

--- a/filter-plugin/logstash-filter-cockroachdb-guardium/README.md
+++ b/filter-plugin/logstash-filter-cockroachdb-guardium/README.md
@@ -184,7 +184,7 @@ The rsyslog template **must** include `serverHostname=` and `serverPort=` values
    $MaxMessageSize 64k
 
    template(name="AuditFormat" type="string"
-     string="<%PRI%>1 %TIMESTAMP:::date-rfc3339% %HOSTNAME% %APP-NAME% - - - serverHostname=<SERVER_HOSTNAME> serverPort=<SERVER_PORT> %rawmsg%\n"
+     string="<%PRI%>1 %TIMESTAMP:::date-rfc3339% %HOSTNAME% %APP-NAME% - - - serverHostname=<SERVER_HOSTNAME> serverPort=<SERVER_PORT> %msg%\n"
    )
 
    ruleset(name="imfile_to_gdp") {
@@ -232,7 +232,7 @@ The rsyslog template **must** include `serverHostname=` and `serverPort=` values
    Replace the `template()` block with the following. Everything else remains the same.
    ```
    template(name="AuditFormat" type="string"
-     string="<%PRI%>%TIMESTAMP:::date-rfc3164% %HOSTNAME% %APP-NAME%: serverHostname=<SERVER_HOSTNAME> serverPort=<SERVER_PORT> %rawmsg%\n"
+     string="<%PRI%>%TIMESTAMP:::date-rfc3164% %HOSTNAME% %APP-NAME%: serverHostname=<SERVER_HOSTNAME> serverPort=<SERVER_PORT> %msg%\n"
    )
    ```
 


### PR DESCRIPTION
### Summary of PR
- Update config



### Testing Results

### Template test
     string="<%PRI%>1 %TIMESTAMP:::date-rfc3339% %HOSTNAME% %APP-NAME% - - - serverHostname=<SERVER_HOSTNAME> serverPort=<SERVER_PORT> %msg%\n"

Both defined in template 

```
template(name="CockroachAuditFormat" type="string"
  string="<%PRI%>1 %TIMESTAMP:::date-rfc3339% %HOSTNAME% %APP-NAME% - - - serverHostname=test-3339.com serverPort=13245 %msg%\n"
)
```
<img width="350" height="157" alt="Screenshot 2026-08-12 at 11 29 33 AM" src="https://github.com/user-attachments/assets/e0d1bf39-c075-488c-8294-21ff4ef0c1f6" />

Port not defined
```
template(name="CockroachAuditFormat" type="string"
  string="<%PRI%>1 %TIMESTAMP:::date-rfc3339% %HOSTNAME% %APP-NAME% - - - serverHostname=test-3339.com %msg%\n"
)
```
<img width="350" height="142" alt="Screenshot 2026-08-12 at 11 30 56 AM" src="https://github.com/user-attachments/assets/95c9b400-0ba9-4e18-8976-bd59e95248ef" />

Port defined but ServerHostname missing 
```
template(name="CockroachAuditFormat" type="string"
  string="<%PRI%>1 %TIMESTAMP:::date-rfc3339% %HOSTNAME% %APP-NAME% - - - serverPort=3563  %msg%\n"
)
```
<img width="242" height="142" alt="Screenshot 2026-08-12 at 11 32 38 AM" src="https://github.com/user-attachments/assets/99d966d0-a2a7-42ff-8015-d47c31cc6d1f" />


### Template test
 string="<%PRI%>%TIMESTAMP:::date-rfc3164% %HOSTNAME% %APP-NAME%: serverHostname=<SERVER_HOSTNAME> serverPort=<SERVER_PORT> %msg%\n"

Both defined in template
<img width="351" height="100" alt="Screenshot 2026-08-12 at 11 05 17 AM" src="https://github.com/user-attachments/assets/c461c134-204b-419a-b32f-4dc9b3afb900" />

Port not defined
<img width="351" height="100" alt="Screenshot 2026-08-12 at 11 05 32 AM" src="https://github.com/user-attachments/assets/d4673024-ef38-4aff-8644-8e6ec0b75765" />

Port defined but ServerHostname missing 
```
template(name="CockroachAuditFormat" type="string"
   string="<%PRI%>%TIMESTAMP:::date-rfc3164% %HOSTNAME% %APP-NAME%: serverPort=45345 %msg%\n"
)
```

<img width="240" height="94" alt="Screenshot 2026-08-12 at 11 26 59 AM" src="https://github.com/user-attachments/assets/19fa3c66-3596-484c-84ef-ae0fefa98f32" />

