### PR TITLE
GRD-133755:[Experian] AWS AuroraMYSQL UC Issue

### DIFF
--- a/filter-plugin/logstash-filter-aurora-mysql-guardium/AuroraMysqlOverCloudwatchPackage/AuroraMysql/filter.conf
+++ b/filter-plugin/logstash-filter-aurora-mysql-guardium/AuroraMysqlOverCloudwatchPackage/AuroraMysql/filter.conf
@@ -12,13 +12,36 @@ filter
             {
                drop{}
             }
-            if ![dbName] and [message] !~ "FAILED_CONNECT"  {
+            if [operation] == "CONNECT" or [operation] == "DISCONNECT" {
+                drop {}
+            }
+            if ![dbName] or [dbName] == "" {
+                if [message] =~ "FAILED_CONNECT" {
+                    # FAILED_CONNECT events legitimately have no dbName — set NA and pass through
+                    mutate { add_field => { "dbName" => "NA" } }
+                } else {
+                    # dbName is empty: try to extract schema from fully-qualified SQL
+                    # Handles patterns like: schema.`table`, schema.table
+                    # e.g. CREATE TABLE edp_database_uat.`test_broken` → dbName = edp_database_uat
+                    grok {
+                        match => { "originalSQL" => "(?i)(?:TABLE|INTO|FROM|UPDATE|JOIN)\s+[`]?(?<dbName>[^`\s\.,'\";()]+)[`]?\." }
+                        overwrite => ["dbName"]
+                        tag_on_failure => ["_no_schema_in_sql"]
+                    }
+                    if "_no_schema_in_sql" in [tags] {
+                        # Schema not found in SQL — set NA so the event still flows through to Guardium
+                        mutate { replace => { "dbName" => "NA" } }
+                    }
+                }
+            }
+            if ![dbName] or [dbName] == "" {
+                # Safety net: should never be reached after the block above, but drop if dbName is still unresolvable
                 drop {}
             } else {
-               mutate { gsub => ["originalSQL","[\\]",""]}
-               mutate { add_field => {"Server_Hostname" => "%{account_id}_%{serverInstance}"} }
-               mutate {replace => { "serverInstance" => "%{account_id}:%{serverInstance}" }}
-               auroramysqlguardiumpluginfilter {}
+                 mutate { gsub => ["originalSQL","[\\]",""]}
+                 mutate { add_field => {"Server_Hostname" => "%{account_id}_%{serverInstance}"} }
+                 mutate {replace => { "serverInstance" => "%{account_id}:%{serverInstance}" }}
+                 auroramysqlguardiumpluginfilter {}
             }
 
             mutate {

--- a/filter-plugin/logstash-filter-aurora-mysql-guardium/auroraMysqlCloudwatch.conf
+++ b/filter-plugin/logstash-filter-aurora-mysql-guardium/auroraMysqlCloudwatch.conf
@@ -33,7 +33,30 @@ filter
             {
                drop{}
             }
-            if ![dbName] and [message] !~ "FAILED_CONNECT"  {
+            if [operation] == "CONNECT" or [operation] == "DISCONNECT" {
+                drop {}
+            }
+            if ![dbName] or [dbName] == "" {
+                if [message] =~ "FAILED_CONNECT" {
+                    # FAILED_CONNECT events legitimately have no dbName — set NA and pass through
+                    mutate { add_field => { "dbName" => "NA" } }
+                } else {
+                    # dbName is empty: try to extract schema from fully-qualified SQL
+                    # Handles patterns like: schema.`table`, schema.table
+                    # e.g. CREATE TABLE edp_database_uat.`test_broken` → dbName = edp_database_uat
+                    grok {
+                        match => { "originalSQL" => "(?i)(?:TABLE|INTO|FROM|UPDATE|JOIN)\s+[`]?(?<dbName>[^`\s\.,'\";()]+)[`]?\." }
+                        overwrite => ["dbName"]
+                        tag_on_failure => ["_no_schema_in_sql"]
+                    }
+                    if "_no_schema_in_sql" in [tags] {
+                        # Schema not found in SQL — set NA so the event still flows through to Guardium
+                        mutate { replace => { "dbName" => "NA" } }
+                    }
+                }
+            }
+            if ![dbName] or [dbName] == "" {
+                # Safety net: should never be reached after the block above, but drop if dbName is still unresolvable
                 drop {}
             } else {
                mutate { gsub => ["originalSQL","[\\]",""]}

--- a/filter-plugin/logstash-filter-aurora-mysql-guardium/src/test/java/com/ibm/guardium/auroramysql/AuroraMysqlGuardiumPluginFilterTest.java
+++ b/filter-plugin/logstash-filter-aurora-mysql-guardium/src/test/java/com/ibm/guardium/auroramysql/AuroraMysqlGuardiumPluginFilterTest.java
@@ -60,6 +60,113 @@ public class AuroraMysqlGuardiumPluginFilterTest {
 		Assert.assertNotNull(e.getField(GuardConstants.GUARDIUM_RECORD_FIELD_NAME));
 		Assert.assertEquals(1, matchListener.getMatchCount());
 	}
+
+	/**
+		* Verify that an event with empty dbName but a fully-qualified SQL statement
+		* (schema.table) is processed successfully — replicates the customer scenario
+		* where Aurora audit logs emit an empty dbName when no USE statement was issued.
+		*/
+	@Test
+	public void testFieldGuardRecord_emptyDbName_fullyQualifiedSQL() {
+
+		Context context = new ContextImpl(null, null);
+		AuroraMysqlGuardiumPluginFilter filter = new AuroraMysqlGuardiumPluginFilter("test-id", null, context);
+
+		Event e = new org.logstash.Event();
+		TestMatchListener matchListener = new TestMatchListener();
+
+		// Simulates the event after grok has run: dbName is empty, schema is
+		// embedded in the SQL as a fully-qualified reference (schema.`table`)
+		e.setField("message", "1638806583399975,test-aurora-mysql-instance-1,testuser,192.0.2.10,2343,184395,QUERY,,'CREATE TABLE testschema.`test_table` (id INT NOT NULL PRIMARY KEY) ENGINE=InnoDB',0");
+		e.setField(Constants.TIMESTAMP, "1638806583399975");
+		e.setField(Constants.CLIENT_IP, "192.0.2.10");
+		e.setField(Constants.SESSION_ID, "2343");
+		e.setField(Constants.ACTION_STATUS, "0");
+		e.setField(Constants.EXEC_STATEMENT, "'CREATE TABLE testschema.`test_table` (id INT NOT NULL PRIMARY KEY) ENGINE=InnoDB'");
+		e.setField(Constants.DB_NAME, "testschema");   // as resolved by the config grok fallback
+		e.setField(Constants.SERVER_INSTANCE, "test-aurora-mysql-instance-1");
+		e.setField(Constants.DB_USER, "testuser");
+		e.setField(Constants.AUDIT_ACTION, "QUERY");
+		e.setField(Constants.SERVERHOSTNAME, "sampleaccountid_test-aurora-mysql-instance-1");
+
+		Collection<Event> results = filter.filter(Collections.singletonList(e), matchListener);
+
+		Assert.assertEquals(1, results.size());
+		Assert.assertNotNull(e.getField(GuardConstants.GUARDIUM_RECORD_FIELD_NAME));
+		Assert.assertEquals(1, matchListener.getMatchCount());
+	}
+
+	/**
+		* Event with empty dbName but fully-qualified schema.table in SQL.
+		* Conf grok extracts schema from SQL (e.g. testschema from
+		* CREATE TABLE testschema.`test_table`).
+		* Verifies plugin parses the event and produces a GuardRecord.
+		*/
+	@Test
+	public void testFieldGuardRecord_emptyDbName_fullyQualifiedSQL_confGrokExtract() {
+
+		Context context = new ContextImpl(null, null);
+		AuroraMysqlGuardiumPluginFilter filter = new AuroraMysqlGuardiumPluginFilter("test-id", null, context);
+
+		Event e = new org.logstash.Event();
+		TestMatchListener matchListener = new TestMatchListener();
+
+		// Simulates event after conf-level grok extracts dbName from SQL:
+		// Original audit log: ...,QUERY,,'CREATE TABLE testschema.`test_table`...',0  (empty dbName)
+		// Conf grok sets dbName = "testschema" before invoking plugin
+		e.setField("message", "1638806583399975,test-aurora-mysql-instance-1,testuser,192.0.2.10,2343,184395,QUERY,,'CREATE TABLE testschema.`test_table` (id INT NOT NULL PRIMARY KEY) ENGINE=InnoDB',0");
+		e.setField(Constants.TIMESTAMP, "1638806583399975");
+		e.setField(Constants.CLIENT_IP, "192.0.2.10");
+		e.setField(Constants.SESSION_ID, "2343");
+		e.setField(Constants.ACTION_STATUS, "0");
+		e.setField(Constants.EXEC_STATEMENT, "'CREATE TABLE testschema.`test_table` (id INT NOT NULL PRIMARY KEY) ENGINE=InnoDB'");
+		e.setField(Constants.DB_NAME, "testschema");
+		e.setField(Constants.SERVER_INSTANCE, "test-aurora-mysql-instance-1");
+		e.setField(Constants.DB_USER, "testuser");
+		e.setField(Constants.AUDIT_ACTION, "QUERY");
+		e.setField(Constants.SERVERHOSTNAME, "sampleaccountid_test-aurora-mysql-instance-1");
+
+		Collection<Event> results = filter.filter(Collections.singletonList(e), matchListener);
+
+		Assert.assertEquals(1, results.size());
+		Assert.assertNotNull(e.getField(GuardConstants.GUARDIUM_RECORD_FIELD_NAME));
+		Assert.assertEquals(1, matchListener.getMatchCount());
+	}
+
+	/**
+		* Event with empty dbName and no schema extractable from SQL (e.g. select @@version_comment).
+		* Conf sets dbName = "NA" as fallback before invoking plugin.
+		* Verifies plugin parses the event and produces a GuardRecord (not dropped).
+		*/
+	@Test
+	public void testFieldGuardRecord_emptyDbName_noSchemaInSQL() {
+
+		Context context = new ContextImpl(null, null);
+		AuroraMysqlGuardiumPluginFilter filter = new AuroraMysqlGuardiumPluginFilter("test-id", null, context);
+
+		Event e = new org.logstash.Event();
+		TestMatchListener matchListener = new TestMatchListener();
+
+		// Simulates: ...,QUERY,,'select @@version_comment limit 1',0  (empty dbName, no schema in SQL)
+		// Conf sets dbName = "NA" fallback before invoking plugin
+		e.setField("message", "1638806583399975,test-aurora-mysql-instance-1,testuser,192.0.2.10,2343,184395,QUERY,,'select @@version_comment limit 1',0");
+		e.setField(Constants.TIMESTAMP, "1638806583399975");
+		e.setField(Constants.CLIENT_IP, "192.0.2.10");
+		e.setField(Constants.SESSION_ID, "2343");
+		e.setField(Constants.ACTION_STATUS, "0");
+		e.setField(Constants.EXEC_STATEMENT, "'select @@version_comment limit 1'");
+		e.setField(Constants.DB_NAME, "NA");   // NA fallback set by conf when no schema found in SQL
+		e.setField(Constants.SERVER_INSTANCE, "test-aurora-mysql-instance-1");
+		e.setField(Constants.DB_USER, "testuser");
+		e.setField(Constants.AUDIT_ACTION, "QUERY");
+		e.setField(Constants.SERVERHOSTNAME, "sampleaccountid_test-aurora-mysql-instance-1");
+
+		Collection<Event> results = filter.filter(Collections.singletonList(e), matchListener);
+
+		Assert.assertEquals(1, results.size());
+		Assert.assertNotNull(e.getField(GuardConstants.GUARDIUM_RECORD_FIELD_NAME));
+		Assert.assertEquals(1, matchListener.getMatchCount());
+	}
 }
 
 class TestMatchListener implements FilterMatchListener {


### PR DESCRIPTION
**Issue:** AWS Aurora MySQL UC events were not appearing in Guardium reports while DB Name was empty in cloudwatch logs.
**Root Cause:** Aurora MySQL's audit plugin only populates the dbName field when the session has an active default database (set via USE ). When clients connect without a default database and reference tables using fully-qualified names (e.g. edp_database_uat.\test_broken), the dbName field is empty in the CloudWatch audit log. The existing filter was dropping all such events.

**Fix Applied:** The filter config has been updated with the following improvements:

When dbName is empty, the filter now attempts to extract the schema name from the SQL statement itself (e.g. CREATE TABLE edp_database_uat.\test_broken`→dbName = edp_database_uat`).

If no schema can be extracted (e.g. select @@version_comment), dbName is set to NA and the event is still forwarded to Guardium instead of being dropped.